### PR TITLE
Faster cache key

### DIFF
--- a/modelator/Cargo.toml
+++ b/modelator/Cargo.toml
@@ -6,10 +6,11 @@ edition = "2018"
 
 [dependencies]
 clap = "3.0.0-beta.2"
+hex = "0.4.3"
 nom = "6.1.2"
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.62"
-sha256 = "1.0.0"
+sha2 = "0.9.3"
 thiserror = "1.0.24"
 tracing = "0.1.25"
 tracing-subscriber = "0.2.16"

--- a/modelator/src/cache/tla_trace.rs
+++ b/modelator/src/cache/tla_trace.rs
@@ -1,6 +1,8 @@
 use super::Cache;
 use crate::artifact::{TlaConfigFile, TlaFile, TlaTrace};
 use crate::{Error, Options};
+use sha2::Digest;
+use std::collections::BTreeSet;
 
 pub(crate) struct TlaTraceCache {
     cache: Cache,
@@ -25,22 +27,60 @@ impl TlaTraceCache {
     pub(crate) fn key(
         tla_file: &TlaFile,
         tla_config_file: &TlaConfigFile,
-        options: &Options,
     ) -> Result<String, Error> {
-        // parse tla file
-        let tla_parsed_file = crate::module::Apalache::parse(tla_file.clone(), options)?;
+        tracing::debug!("TlaTraceKey:key {} {}", tla_file, tla_config_file);
 
-        // read both the tla parsed file and the tla config file
-        let tla_parsed = std::fs::read_to_string(tla_parsed_file.path()).map_err(Error::io)?;
-        let tla_config = std::fs::read_to_string(tla_config_file.path()).map_err(Error::io)?;
+        // get all tla files in the same directory
+        let mut tla_dir = tla_file.path().clone();
+        assert!(tla_dir.pop());
 
-        // cleanup tla parse file
-        std::fs::remove_file(tla_parsed_file.path())
-            .expect("[modelator] it should be possible to remove tla parsed file just created");
+        let files_to_hash = crate::util::read_dir(&tla_dir)?
+            .into_iter()
+            .filter(|filename| filename.ends_with(".tla"))
+            // compute full path
+            .map(|filename| tla_dir.join(filename))
+            // also hash the tla config file
+            .chain(std::iter::once(tla_config_file.path().clone()))
+            .map(|path| crate::util::absolute_path(&path))
+            // sort files so that the hash is deterministic
+            .collect();
 
-        // combine both and hash them
-        let combined = tla_parsed + &tla_config;
-        let hash = sha256::digest(&combined);
+        tracing::debug!("files to hash: {:?}", files_to_hash);
+        let mut digest = hash_files(files_to_hash)?;
+
+        // also add the absolute path of the tla file to the digest; this makes
+        // sure that two tla tests files living in the same directory and using
+        // the same tla configuration (which we shouldn't happen when using
+        // `modelator::module::tla::generate_tests`) will have different hashes
+        digest.update(&crate::util::absolute_path(&tla_file.path()));
+
+        let hash = hex::encode(digest.finalize());
+        tracing::debug!("computed hash: {}", hash);
         Ok(hash)
     }
+}
+
+fn hash_files(paths: BTreeSet<String>) -> Result<sha2::Sha256, Error> {
+    let mut digest = sha2::Sha256::default();
+    for path in paths {
+        hash_file(path, &mut digest)?;
+    }
+    Ok(digest)
+}
+
+fn hash_file(path: String, digest: &mut sha2::Sha256) -> Result<(), Error> {
+    let file = std::fs::File::open(path).map_err(Error::io)?;
+    let mut reader = std::io::BufReader::new(file);
+
+    let mut buffer = [0; 1024];
+    loop {
+        use std::io::Read;
+        let count = reader.read(&mut buffer).map_err(Error::io)?;
+        if count == 0 {
+            break;
+        }
+        digest.update(&buffer[..count]);
+    }
+
+    Ok(())
 }

--- a/modelator/src/error.rs
+++ b/modelator/src/error.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 use std::fmt::Debug;
 use thiserror::Error;
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Error, Debug, Serialize)]
 pub enum Error {
     #[error("IO error: {0}")]

--- a/modelator/src/module/apalache/mod.rs
+++ b/modelator/src/module/apalache/mod.rs
@@ -30,7 +30,7 @@ impl Apalache {
 
         // load cache and check if the result is cached
         let mut cache = TlaTraceCache::new(options)?;
-        let cache_key = TlaTraceCache::key(&tla_file, &tla_config_file, options)?;
+        let cache_key = TlaTraceCache::key(&tla_file, &tla_config_file)?;
         if let Some(value) = cache.get(&cache_key)? {
             return Ok(value);
         }

--- a/modelator/src/module/tla/mod.rs
+++ b/modelator/src/module/tla/mod.rs
@@ -4,7 +4,7 @@ mod json;
 use crate::artifact::{JsonTrace, TlaConfigFile, TlaFile, TlaTrace};
 use crate::Error;
 use serde_json::Value as JsonValue;
-use std::path::PathBuf;
+use std::path::Path;
 
 // #[modelator::module]
 pub struct Tla;
@@ -93,7 +93,7 @@ fn extract_test_names(tla_test_file: &TlaFile) -> Result<Vec<String>, Error> {
 }
 
 fn generate_test(
-    tla_tests_dir: &PathBuf,
+    tla_tests_dir: &Path,
     tla_tests_module_name: &str,
     test_name: &str,
     tla_config_file: &TlaConfigFile,

--- a/modelator/src/module/tlc/mod.rs
+++ b/modelator/src/module/tlc/mod.rs
@@ -25,7 +25,7 @@ impl Tlc {
 
         // load cache and check if the result is cached
         let mut cache = TlaTraceCache::new(options)?;
-        let cache_key = TlaTraceCache::key(&tla_file, &tla_config_file, options)?;
+        let cache_key = TlaTraceCache::key(&tla_file, &tla_config_file)?;
         if let Some(value) = cache.get(&cache_key)? {
             return Ok(value);
         }

--- a/modelator/src/util.rs
+++ b/modelator/src/util.rs
@@ -1,6 +1,6 @@
 use crate::Error;
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 pub(crate) fn cmd_output_to_string(output: &[u8]) -> String {
@@ -23,8 +23,8 @@ pub(crate) fn check_file_existence<P: AsRef<Path>>(path: P) -> Result<(), Error>
     }
 }
 
-pub(crate) fn absolute_path(path: &PathBuf) -> String {
-    match path.canonicalize() {
+pub(crate) fn absolute_path<P: AsRef<Path>>(path: P) -> String {
+    match path.as_ref().canonicalize() {
         Ok(path) => path.to_string_lossy().to_string(),
         Err(e) => panic!("[modelator] couldn't compute absolute path: {:?}", e),
     }


### PR DESCRIPTION
The caching strategy introduced in #39 ended up not bringing any benefits to MBT in [ibc-rs](https://github.com/informalsystems/ibc-rs/): https://github.com/informalsystems/modelator/pull/39#issuecomment-806099190
This was due to the cost of computing the cache key (which was using `modelator::module::Apalache::parse`).

This PR introduces a new strategy for computing the cache key: read all TLA+ files in the directory where the TLA+ test file is and hash their content.

#### Potential issues:
- _cache is not used but should_: the user changes an unrelated TLA+ file and as a result the cached output is not used
- _cache is used but shouldn't_: the user changes some java code that changes the behaviour of some TLA+ module; in this case, the cache should be invalidated but it won't (arguably this cannot happen in the current version of `modelator` as we don't allow this kind of "imports")

#### Results for MBT in ibc-rs:
- not-cached:
  - before this PR: 32s
  - after this PR: 18s
- cached:
  - before this PR: 16s
  - after this PR: 1s 