### PR TITLE
Setup modelator on all methods

### DIFF
--- a/modelator/src/artifact/tla_cfg_file.rs
+++ b/modelator/src/artifact/tla_cfg_file.rs
@@ -13,6 +13,9 @@ impl TlaConfigFile {
     pub(crate) fn new<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
         let path = path.as_ref().to_path_buf();
         crate::util::check_file_existence(&path)?;
+        let path = path
+            .canonicalize()
+            .expect("[modelator] existing file can be canonicalized");
         Ok(Self { path })
     }
 

--- a/modelator/src/artifact/tla_file.rs
+++ b/modelator/src/artifact/tla_file.rs
@@ -12,6 +12,9 @@ impl TlaFile {
     pub(crate) fn new<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
         let path = path.as_ref().to_path_buf();
         crate::util::check_file_existence(&path)?;
+        let path = path
+            .canonicalize()
+            .expect("[modelator] existing file can be canonicalized");
         Ok(Self { path })
     }
 

--- a/modelator/src/cli/mod.rs
+++ b/modelator/src/cli/mod.rs
@@ -82,8 +82,6 @@ impl CliOptions {
 
 impl Modules {
     fn run(self) -> Result<JsonValue, Error> {
-        let options = crate::Options::default();
-
         // run the subcommand
         match self {
             Self::Tla(options) => options.run(),

--- a/modelator/src/cli/mod.rs
+++ b/modelator/src/cli/mod.rs
@@ -82,9 +82,7 @@ impl CliOptions {
 
 impl Modules {
     fn run(self) -> Result<JsonValue, Error> {
-        // setup modelator
         let options = crate::Options::default();
-        crate::setup(&options)?;
 
         // run the subcommand
         match self {

--- a/modelator/src/lib.rs
+++ b/modelator/src/lib.rs
@@ -75,9 +75,6 @@ pub fn traces<P: AsRef<Path>>(
     tla_config_file: P,
     options: &Options,
 ) -> Result<Vec<artifact::JsonTrace>, Error> {
-    // setup modelator
-    setup(&options)?;
-
     // generate tla tests
     use std::convert::TryFrom;
     let tla_tests_file = artifact::TlaFile::try_from(tla_tests_file.as_ref())?;

--- a/modelator/src/module/apalache/mod.rs
+++ b/modelator/src/module/apalache/mod.rs
@@ -39,6 +39,9 @@ impl Apalache {
         tla_config_file: TlaConfigFile,
         options: &Options,
     ) -> Result<TlaTrace, Error> {
+        // setup modelator
+        crate::setup(&options)?;
+
         tracing::debug!(
             "Apalache::test {} {} {:?}",
             tla_file,
@@ -93,6 +96,9 @@ impl Apalache {
     /// println!("{:?}", tla_parsed_file);
     /// ```
     pub fn parse(tla_file: TlaFile, options: &Options) -> Result<TlaFile, Error> {
+        // setup modelator
+        crate::setup(&options)?;
+
         tracing::debug!("Apalache::parse {} {:?}", tla_file, options);
 
         // compute the directory in which the tla file is stored

--- a/modelator/src/module/tlc/mod.rs
+++ b/modelator/src/module/tlc/mod.rs
@@ -39,6 +39,9 @@ impl Tlc {
         tla_config_file: TlaConfigFile,
         options: &Options,
     ) -> Result<TlaTrace, Error> {
+        // setup modelator
+        crate::setup(&options)?;
+
         tracing::debug!("Tlc::test {} {} {:?}", tla_file, tla_config_file, options);
 
         // load cache and check if the result is cached


### PR DESCRIPTION
Before this PR, calling e.g. `modelator::module::Apalache::parse` would fail if `crate::setup` (which downloads the model checkers) hadn't been called before.

This PR addresses this issue by ensuring that `crate::setup` is called on all methods that need the model checkers.

This PR also canonicalizes the paths in the artifacts `TlaFile`and `TlaConfigFile`. This ensures that the directory of some `tla_file` can be correctly computed with
```rust
let mut tla_dir = tla_file.path().clone();
assert!(tla_dir.pop());
```
as we do e.g in `modelator::module::Tla::generate_tests`: https://github.com/informalsystems/modelator/blob/e3e859d70694d5c79ddd414f8668f4506157e608/modelator/src/module/tla/mod.rs#L69-L71