### PR TITLE
Cargo touchups

### DIFF
--- a/modelator/Cargo.toml
+++ b/modelator/Cargo.toml
@@ -9,11 +9,12 @@ keywords   = ["testing", "model", "model-based", "TLA", "abstraction"]
 repository = "https://github.com/informalsystems/modelator"
 authors = [
     "Vitor Enes <vitorenesduarte@gmail.com>", 
-    "Andrey Kuprianov <andrey@informal.systems>"
+    "Andrey Kuprianov <andrey@informal.systems>",
+    "Ranadeep Biswas <ranadeep@informal.systems>"
 ]
 
 [dependencies]
-clap = "3.0.0-beta.4"
+clap = "=3.0.0-beta.4"
 hex = "0.4.3"
 nom = "6.2.1"
 serde = { version = "1.0.127", features = ["derive"] }

--- a/modelator/Cargo.toml
+++ b/modelator/Cargo.toml
@@ -13,19 +13,19 @@ authors = [
 ]
 
 [dependencies]
-clap = "3.0.0-beta.2"
+clap = "3.0.0-beta.4"
 hex = "0.4.3"
-nom = "6.1.2"
-serde = { version = "1.0.123", features = ["derive"] }
-serde_json = "1.0.62"
-sha2 = "0.9.3"
-thiserror = "1.0.24"
-tracing = "0.1.25"
-tracing-subscriber = "0.2.16"
-ureq = "2.1.0"
-tempfile = "3"
+nom = "6.2.1"
+serde = { version = "1.0.127", features = ["derive"] }
+serde_json = "1.0.66"
+sha2 = "0.9.5"
+thiserror = "1.0.26"
+tracing = "0.1.26"
+tracing-subscriber = "0.2.19"
+ureq = "2.1.1"
+tempfile = "3.2.0"
 
 [dev-dependencies]
-once_cell = "1.7.2"
+once_cell = "1.8.0"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"

--- a/modelator/Cargo.toml
+++ b/modelator/Cargo.toml
@@ -19,11 +19,11 @@ nom = "6.2.1"
 serde = { version = "1.0.127", features = ["derive"] }
 serde_json = "1.0.66"
 sha2 = "0.9.5"
+tempfile = "3.2.0"
 thiserror = "1.0.26"
 tracing = "0.1.26"
 tracing-subscriber = "0.2.19"
 ureq = "2.1.1"
-tempfile = "3.2.0"
 
 [dev-dependencies]
 once_cell = "1.8.0"

--- a/modelator/src/cache/tla_trace.rs
+++ b/modelator/src/cache/tla_trace.rs
@@ -14,7 +14,7 @@ impl TlaTraceCache {
 
     #[allow(clippy::ptr_arg)]
     pub(crate) fn get(&self, key: &String) -> Result<Option<TlaTrace>, Error> {
-        self.cache.get(&key)?.map(|value| value.parse()).transpose()
+        self.cache.get(key)?.map(|value| value.parse()).transpose()
     }
 
     pub(crate) fn insert(&mut self, key: String, tla_trace: &TlaTrace) -> Result<(), Error> {

--- a/modelator/src/datachef.rs
+++ b/modelator/src/datachef.rs
@@ -265,7 +265,7 @@ impl Recipe {
         let type_ids = (TypeId::of::<From>(), TypeId::of::<To>());
         self.converts.get(&type_ids).and_then(|f| {
             f.downcast_ref::<fn(&Self, From) -> To>()
-                .map(|f| Box::new(move |x: From| f(&self, x)) as Box<dyn Fn(From) -> To>)
+                .map(|f| Box::new(move |x: From| f(self, x)) as Box<dyn Fn(From) -> To>)
         })
     }
 
@@ -277,7 +277,7 @@ impl Recipe {
         let type_ids = (name.to_string(), TypeId::of::<From>(), TypeId::of::<To>());
         self.named_converts.get(&type_ids).and_then(|f| {
             f.downcast_ref::<fn(&Self, From) -> To>()
-                .map(|f| Box::new(move |x: From| f(&self, x)) as Box<dyn Fn(From) -> To>)
+                .map(|f| Box::new(move |x: From| f(self, x)) as Box<dyn Fn(From) -> To>)
         })
     }
 
@@ -285,7 +285,7 @@ impl Recipe {
         let type_id = TypeId::of::<T>();
         self.defaults.get(&type_id).and_then(|f| {
             f.downcast_ref::<fn(&Self) -> T>()
-                .map(|f| Box::new(move || f(&self)) as Box<dyn Fn() -> T>)
+                .map(|f| Box::new(move || f(self)) as Box<dyn Fn() -> T>)
         })
     }
 
@@ -295,7 +295,7 @@ impl Recipe {
             .get(&(name.to_string(), type_id))
             .and_then(|f| {
                 f.downcast_ref::<fn(&Self) -> T>()
-                    .map(|f| Box::new(move || f(&self)) as Box<dyn Fn() -> T>)
+                    .map(|f| Box::new(move || f(self)) as Box<dyn Fn() -> T>)
             })
     }
 }
@@ -359,7 +359,7 @@ mod tests {
         });
 
         assert!(check_record(r.make("John Smith".to_string())));
-        assert!(!check_record(r.make("short".repeat(1))));
+        assert!(!check_record(r.make("short".to_string())));
         assert!(!check_record(r.make("long".repeat(100))));
 
         r.add(|_, phone: (u32, u32)| Phone {
@@ -426,11 +426,11 @@ mod tests {
             id: r.take_as("id"),
         });
         r.add(|r, name: String| Provider {
-            name: name,
+            name,
             id: r.take_as("id"),
         });
         r.add(|r, name: String| Chain {
-            name: name.clone(),
+            name,
             id: r.take_as("id"),
             default_provider: r.take(),
         });

--- a/modelator/src/jar.rs
+++ b/modelator/src/jar.rs
@@ -78,7 +78,7 @@ pub(crate) fn download_jars<P: AsRef<Path>>(modelator_dir: P) -> Result<(), Erro
     // compute jars that are missing
     let missing_jars: HashSet<_> = Jar::all()
         .into_iter()
-        .filter(|jar| !existing_jars.contains(&jar))
+        .filter(|jar| !existing_jars.contains(jar))
         .collect();
 
     if !missing_jars.is_empty() {

--- a/modelator/src/lib.rs
+++ b/modelator/src/lib.rs
@@ -88,7 +88,7 @@ pub fn traces<P: AsRef<Path>>(
     options: &Options,
 ) -> Result<Vec<artifact::JsonTrace>, Error> {
     // setup modelator
-    setup(&options)?;
+    setup(options)?;
 
     // create a temporary directory, and copy TLA+ files there
     let dir = tempdir().map_err(Error::io)?;

--- a/modelator/src/tester.rs
+++ b/modelator/src/tester.rs
@@ -263,7 +263,7 @@ mod tests {
     }
 
     fn fails(_: MyTest2) {
-        assert!(false);
+        unreachable!();
     }
 
     fn succeeds_if_my_test(t: MyTest) {

--- a/modelator/src/util.rs
+++ b/modelator/src/util.rs
@@ -137,7 +137,7 @@ fn list_files<P: AsRef<Path>>(ext: &str, file: P) -> Result<Vec<PathBuf>, Error>
                 .unwrap_or_default()
         })
         .map(|dir_entry| dir_entry.path())
-        .filter(|file_path| is_ext(&file_path))
+        .filter(|file_path| is_ext(file_path))
         .collect();
     Ok(files)
 }

--- a/modelator/tests/integration/main.rs
+++ b/modelator/tests/integration/main.rs
@@ -1,7 +1,7 @@
 // We follow the approach proposed in the following link for integration tests:
 // https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html
 
-use modelator::artifact::{JsonTrace};
+use modelator::artifact::JsonTrace;
 use modelator::test_util::NumberSystem;
 use modelator::{ActionHandler, EventRunner, EventStream, StateHandler};
 use modelator::{CliOptions, CliStatus, Error, ModelChecker, ModelCheckerOptions, Options};
@@ -292,14 +292,8 @@ fn absolute_and_relative_paths(
     let absolute_tla_tests_file = relative_tla_tests_file.canonicalize().unwrap();
     let absolute_tla_config_file = relative_tla_config_file.canonicalize().unwrap();
     vec![
-        (
-            relative_tla_tests_file,
-            relative_tla_config_file,
-        ),
-        (
-            absolute_tla_tests_file,
-            absolute_tla_config_file,
-        ),
+        (relative_tla_tests_file, relative_tla_config_file),
+        (absolute_tla_tests_file, absolute_tla_config_file),
     ]
 }
 

--- a/modelator/tests/integration/main.rs
+++ b/modelator/tests/integration/main.rs
@@ -1,7 +1,7 @@
 // We follow the approach proposed in the following link for integration tests:
 // https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html
 
-use modelator::artifact::{JsonTrace, TlaFile};
+use modelator::artifact::{JsonTrace};
 use modelator::test_util::NumberSystem;
 use modelator::{ActionHandler, EventRunner, EventStream, StateHandler};
 use modelator::{CliOptions, CliStatus, Error, ModelChecker, ModelCheckerOptions, Options};
@@ -104,7 +104,7 @@ fn event_runner() {
 //     assert!(run(tla_tests_file, tla_config_file, &options, &mut runner).is_ok());
 // }
 
-const TLA_DIR: &'static str = "tests/integration/tla";
+const TLA_DIR: &str = "tests/integration/tla";
 
 // we use this lock to make sure that the tlc & apalache tests are not run in
 // parallel
@@ -113,6 +113,7 @@ static LOCK: Lazy<Mutex<()>> = Lazy::new(Mutex::default);
 // TODO: disabled because of non-deterministic test failures
 // see https://github.com/informalsystems/modelator/issues/43
 // #[test]
+#[allow(dead_code)]
 fn tlc() {
     let _guard = LOCK.lock();
     if let Err(e) = all_tests(ModelChecker::Tlc) {
@@ -184,6 +185,7 @@ fn all_tests(model_checker: ModelChecker) -> Result<(), Error> {
     Ok(())
 }
 
+#[allow(dead_code)]
 fn cli_traces<P: AsRef<Path>>(
     tla_tests_file: P,
     tla_config_file: P,
@@ -204,7 +206,7 @@ fn cli_traces<P: AsRef<Path>>(
         .result
         .as_array()
         .unwrap()
-        .into_iter()
+        .iter()
         .map(|json_entry| {
             let test = json_entry.as_object().unwrap();
             (
@@ -291,12 +293,12 @@ fn absolute_and_relative_paths(
     let absolute_tla_config_file = relative_tla_config_file.canonicalize().unwrap();
     vec![
         (
-            relative_tla_tests_file.clone(),
-            relative_tla_config_file.clone(),
+            relative_tla_tests_file,
+            relative_tla_config_file,
         ),
         (
-            absolute_tla_tests_file.clone(),
-            absolute_tla_config_file.clone(),
+            absolute_tla_tests_file,
+            absolute_tla_config_file,
         ),
     ]
 }


### PR DESCRIPTION
This series of commits addresses cargo etiquettes.

`cargo upgrade` is done by [`cargo-edit`](https://crates.io/crates/cargo-edit).