### PR TITLE
Adds support for user defined View operators when using Apalache

### DIFF
--- a/modelator/Cargo.toml
+++ b/modelator/Cargo.toml
@@ -27,6 +27,8 @@ thiserror = "1.0.26"
 tracing = "0.1.26"
 tracing-subscriber = "0.2.19"
 ureq = "2.1.1"
+regex = "1.5"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 clap_generate = "=3.0.0-beta.4"

--- a/modelator/src/artifact/tla_file_suite.rs
+++ b/modelator/src/artifact/tla_file_suite.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::iter::once;
 use std::path::PathBuf;
 
 use super::tla_config_file::TlaConfigFile;

--- a/modelator/src/artifact/tla_file_suite.rs
+++ b/modelator/src/artifact/tla_file_suite.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeSet;
-use std::iter::once;
 use std::path::PathBuf;
 
 use super::tla_config_file::TlaConfigFile;

--- a/modelator/src/error.rs
+++ b/modelator/src/error.rs
@@ -36,6 +36,10 @@ pub enum Error {
     #[error("No test found in {0}")]
     NoTestFound(String),
 
+    /// Tla operator name parse error
+    #[error("Unable to parse all operator names in tla module with content: {0}")]
+    TlaOperatorNameParseError(String),
+
     /// An error that occurs when the model checker isn't able to generate a test trace.
     #[error("No trace found in {0}")]
     NoTestTraceFound(std::path::PathBuf),

--- a/modelator/src/model/checker/apalache/mod.rs
+++ b/modelator/src/model/checker/apalache/mod.rs
@@ -75,14 +75,11 @@ impl Apalache {
         // Check if the main tla module contains a View
         // The view will have a generated name 'ViewForTestNeg'
         // If it has one, then use it.
-        let view = match input_artifacts
+        let view = input_artifacts
             .tla_file
             .file_contents_backing()
             .contains("ViewForTestNeg")
-        {
-            true => Some("ViewForTestNeg".to_owned()),
-            false => None,
-        };
+            .then(|| "ViewForTestNeg".to_owned());
 
         // create 'apalache test' command
         let cmd = check_cmd(

--- a/modelator/src/model/checker/apalache/mod.rs
+++ b/modelator/src/model/checker/apalache/mod.rs
@@ -73,6 +73,8 @@ impl Apalache {
         let cmd = apalache_start_cmd(&tdir, runtime);
 
         // Check if the main tla module contains a View
+        // The view will have a generated name 'ViewForTestNeg'
+        // If it has one, then use it.
         let view = match input_artifacts
             .tla_file
             .file_contents_backing()

--- a/modelator/src/model/checker/apalache/mod.rs
+++ b/modelator/src/model/checker/apalache/mod.rs
@@ -72,12 +72,23 @@ impl Apalache {
         // Gets Apalache command with tdir as working dir
         let cmd = apalache_start_cmd(&tdir, runtime);
 
+        // Check if the main tla module contains a View
+        let view = match input_artifacts
+            .tla_file
+            .file_contents_backing()
+            .contains("ViewForTestNeg")
+        {
+            true => Some("ViewForTestNeg".to_owned()),
+            false => None,
+        };
+
         // create 'apalache test' command
-        let cmd = test_cmd(
+        let cmd = check_cmd(
             cmd,
             input_artifacts.tla_file.file_name(),
             input_artifacts.tla_config_file.filename(),
             runtime.model_checker_runtime.traces_per_test,
+            &view,
         );
 
         tracing::warn!(
@@ -193,19 +204,25 @@ fn run_apalache(mut cmd: Command) -> Result<CmdOutput, Error> {
     Ok(CmdOutput { stdout, stderr })
 }
 
-fn test_cmd<P: AsRef<Path>>(
+fn check_cmd<P: AsRef<Path>>(
     mut cmd: Command,
     tla_file_base_name: P,
     tla_config_file_base_name: P,
     max_error: usize,
+    view: &Option<String>,
 ) -> Command {
     cmd.arg("check")
         .arg(format!(
             "--config={}",
             tla_config_file_base_name.as_ref().to_string_lossy()
         ))
-        .arg(format!("--max-error={}", max_error))
-        .arg(tla_file_base_name.as_ref());
+        .arg(format!("--max-error={}", max_error));
+
+    if view.is_some() {
+        cmd.arg(format!("--view={}", view.as_ref().unwrap()));
+    };
+
+    cmd.arg(tla_file_base_name.as_ref());
 
     // show command being run
     tracing::debug!("{}", crate::util::cmd_show(&cmd));

--- a/modelator/src/model/checker/apalache/mod.rs
+++ b/modelator/src/model/checker/apalache/mod.rs
@@ -217,8 +217,8 @@ fn check_cmd<P: AsRef<Path>>(
         ))
         .arg(format!("--max-error={}", max_error));
 
-    if view.is_some() {
-        cmd.arg(format!("--view={}", view.as_ref().unwrap()));
+    if let Some(view_inner) = view {
+        cmd.arg(format!("--view={}", view_inner));
     };
 
     cmd.arg(tla_file_base_name.as_ref());

--- a/modelator/src/model/language/tla/mod.rs
+++ b/modelator/src/model/language/tla/mod.rs
@@ -201,17 +201,18 @@ fn extract_view_operator(
     Ok(operators.iter().fold(None, |acc, s| -> Option<String> {
         // If the operator is a test specific view then use it
         if *s == format!("{}View", test_name) {
-            return Some(s.clone());
+            Some(s.clone())
         }
         // If a test specific view has already been found then use it
-        if acc.is_some() && acc != Some("View".to_owned()) {
-            return acc;
+        else if acc.is_some() && acc != Some("View".to_owned()) {
+            acc
         }
         // Otherwise if a View has been found then use it
-        if s == "View" {
-            return Some("View".to_owned());
+        else if s == "View" {
+            Some("View".to_owned())
+        } else {
+            acc
         }
-        acc
     }))
 }
 


### PR DESCRIPTION
_Will close  Implement View for Apalache multiple tests #98_


Automatically detects View operators in the .tla module that is passed as the target of the `trace` command.

The rules are as follow:
```
for each test named <test_name> in module:
  if an operator exists named <test_name>View:
    use it for the test <test_name>
  else if an operator exists named View:
    use it for the test <test_name>
```

The implementation is done by

1. in `tla::generate_test` (this produces the module file with the negated invariant) also add a view `ViewForTestNeg==<UserDefinedViewName>` if found.
2. Use `ViewForTestNeg` as a view in `apalache::test` if one is found.

This design removes data data dependencies between the tla and apalache modules but may not be as efficient as other solutions (have to do a little bit more parsing).

```
------------------------------ MODULE mainTests --------------------------------

EXTENDS main

\* @type: () => <<Int>>;
View == <<foo>>

\* ~~~~~~~~~

Var0Test == var = 6

\* @type: () => <<Int>>;
Var0TestView == <<foo>>

\* ~~~~~~~~~

Var1Test == var = 7

\* @type: () => <<Int>>;
Var1TestView == <<foo>>

\* ~~~~~~~~~

Var2Test == var = 8

\* @type: () => <<Int>>;
Var2TestView == <<foo>>

===============================================================================
```