### PR TITLE
Removes TempDir::into_path usage

### DIFF
--- a/modelator/src/model/checker/apalache/mod.rs
+++ b/modelator/src/model/checker/apalache/mod.rs
@@ -171,7 +171,7 @@ impl Apalache {
         }
 
         // create tla file
-        let full_output_path = tdir.into_path().join(output_path);
+        let full_output_path = tdir.path().join(output_path);
         let tla_parsed_file = TlaFile::try_read_from_file(full_output_path)?;
         Ok((
             tla_parsed_file,


### PR DESCRIPTION
This replaces one use of `TempDir::into_path` with `TempDir::path`. Using `into_path` is wrong because

> Unwraps the Path contained in the TempDir and returns it. This destroys the TempDir without deleting the directory represented by the returned Path.

[link](https://docs.rs/tempdir/0.3.7/tempdir/struct.TempDir.html#method.into_path)