### PR TITLE
Parallel integration tests

### DIFF
--- a/modelator/src/model/checker/apalache/mod.rs
+++ b/modelator/src/model/checker/apalache/mod.rs
@@ -250,6 +250,10 @@ fn apalache_start_cmd(temp_dir: &tempfile::TempDir, runtime: &ModelatorRuntime) 
             temp_dir.path().to_string_lossy()
         ))
         .arg("-jar")
+        .arg(format!(
+            "-Djava.io.tmpdir={}",
+            temp_dir.path().to_string_lossy()
+        ))
         .arg(format!("{}", apalache.as_path().to_string_lossy()));
 
     cmd


### PR DESCRIPTION
Parallel integration tests were reverted (#111) because of a race condition bug (tlaplus/tlaplus#688).

This PR introduces the mentioned workaround and brings back parallel integration tests.

_Addresses #120_