### PR TITLE
Store jars in user specific directory

### DIFF
--- a/.changelog/unreleased/notes/rust/137-jar-dir.md
+++ b/.changelog/unreleased/notes/rust/137-jar-dir.md
@@ -1,0 +1,1 @@
+A unique directory to store model-checker jars.

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -185,6 +185,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +380,7 @@ version = "0.4.0"
 dependencies = [
  "clap",
  "clap_generate",
+ "directories",
  "hex",
  "lazy_static",
  "nom",
@@ -575,6 +596,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
 ]
 
 [[package]]

--- a/rs/modelator/Cargo.toml
+++ b/rs/modelator/Cargo.toml
@@ -17,6 +17,7 @@ authors = [
 
 [dependencies]
 clap = "=3.0.0-beta.5"
+directories = "4.0.1"
 hex = "0.4.3"
 lazy_static = "1.4.0"
 nom = "7.1.0"

--- a/rs/modelator/src/jar.rs
+++ b/rs/modelator/src/jar.rs
@@ -93,7 +93,10 @@ pub(crate) fn download_jars_if_necessary<P: AsRef<Path>>(modelator_dir: P) -> Re
 
     if !missing_jars.is_empty() {
         // download missing jars
-        println!("[modelator] Downloading model-checkers... ");
+        println!(
+            "[modelator] Downloading model-checkers at \"{}\"...",
+            modelator_dir.as_ref().to_string_lossy()
+        );
         for jar in missing_jars {
             jar.download(&modelator_dir)?;
         }

--- a/rs/modelator/src/lib.rs
+++ b/rs/modelator/src/lib.rs
@@ -126,7 +126,10 @@ impl Default for ModelatorRuntime {
     fn default() -> Self {
         Self {
             model_checker_runtime: ModelCheckerRuntime::default(),
-            dir: env::current_dir().unwrap().join(".modelator"), //Path::new(".modelator").to_path_buf(),
+            dir: directories::ProjectDirs::from("systems", "Informal", "modelator")
+                .expect("there is no valid home directory")
+                .data_dir()
+                .into(), // env::home_dir().unwrap().join(".modelator"), //Path::new(".modelator").to_path_buf(),
         }
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #136 

## Description

Use a user specific directory to store jar files of the model checkers and tools, so that they are not downloaded multiple time when switching work directory.

We use `ProjectDirs::from("systems", "Informal", "modelator")?.data_dir()` from [`directories`](https://docs.rs/directories/4.0.1/directories/struct.ProjectDirs.html#method.data_dir).



______

For contributor use:

- [ ] If applicable, unit tests are written and added to CI. (N.A. Old tests takes care of this change)
- [x] Ran `go fmt`, `cargo fmt` and etc. (or had formatting run automatically on all files edited)
- [ ] Updated relevant documentation (`docs/`) and code comments. (N.A. Doesn't change any API)
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
