### PR TITLE
Display `<code>` elements as blocks

### DIFF
--- a/jekyll/_sass/custom/custom.scss
+++ b/jekyll/_sass/custom/custom.scss
@@ -17,3 +17,7 @@
     font-size: xx-large;
     color: $grey-dk-200;
 }
+
+code {
+  display: block;
+}


### PR DESCRIPTION
Before:

<img width="569" alt="Screen Shot 2021-12-02 at 16 11 37" src="https://user-images.githubusercontent.com/106849/144449190-5e727f84-2488-4807-85e0-019205e41ed0.png">

After:
<img width="833" alt="Screen Shot 2021-12-02 at 16 11 50" src="https://user-images.githubusercontent.com/106849/144449227-538fc534-19cf-437c-9e1a-fd11bdd72a96.png">


