### PR TITLE
TLA+ Basics Tutorial: typos and small changes

### DIFF
--- a/jekyll/docs/tla_basics_tutorials/ethereum.md
+++ b/jekyll/docs/tla_basics_tutorials/ethereum.md
@@ -37,7 +37,7 @@ Submit an order allowing `spender` to transfer funds from `sender`'s address on 
 
 The orders are submitted to the pendingTransactions pool. While the pool is not empty the blockchain will select and execute orders from the pool in a non-deterministic order.
 
-You may notice that the descriptions of the _Submit*_ API calls not totally clear with respect to ordering and timing. We will see that this is exactly the problem with the API.
+You may notice that the descriptions of the _Submit*_ API calls are not totally clear with respect to ordering and timing. We will see that this is exactly the problem with the API.
 
 ## Defining State
 
@@ -281,7 +281,7 @@ If the transaction does not fail, funds are transferred: the sender balance decr
 
 ### ProcessTransferFrom
 
-_transfer_ transactions are made by addresses transferring their own funds. _transferFrom_ transactions transfer funds between any two addresses, so long as the caller of transferFrom has been give approval.
+_transfer_ transactions are made by addresses transferring their own funds. _transferFrom_ transactions transfer funds between any two addresses, so long as the caller of transferFrom has been given approval.
 
 ```tla
 ProcessTransferFrom(tx) == 
@@ -389,7 +389,7 @@ In order to use trace invariants we must define a STATE type alias in typdefs.tl
 ```
 It is straightforward to copy the declerations following the VARIABLES keyword that we already wrote.
 
-Given the alias, Foo allows us to access any state in the execution trace using sequence indexing (1-based). For example we can access the initial state with trace[1], the second state with trace[2] ect.
+Given the alias, Foo allows us to access any state in the execution trace using sequence indexing (1-based). For example we can access the initial state with trace[1], the second state with trace[2] etc.
 
 ### Trace Invariant: All Fund Transfers Have Sufficient Approval
 

--- a/jekyll/docs/tla_basics_tutorials/generating_traces.md
+++ b/jekyll/docs/tla_basics_tutorials/generating_traces.md
@@ -10,7 +10,7 @@ nav_order: 7
 
 **The .tla and other referenced files are included [here](https://github.com/informalsystems/modelator/tree/main/jekyll/docs/tla_basics_tutorials/models).**
 
-Apalache allows you to generate more than trace that satisfies a given behavior specified by a [state invariant](https://apalache.informal.systems/docs/tutorials/symbmc.html?highlight=invariant#invariants) or [trace invariant](https://apalache.informal.systems/docs/apalache/invariants.html?highlight=trace#trace-invariants).
+Apalache allows you to generate more than one trace that satisfies a given behavior specified by a [state invariant](https://apalache.informal.systems/docs/tutorials/symbmc.html?highlight=invariant#invariants) or [trace invariant](https://apalache.informal.systems/docs/apalache/invariants.html?highlight=trace#trace-invariants).
 
 Generating multiple traces can be useful because different traces may give you insight into your system. There may be several different methods of exploiting the same vulnerability, for example. Generating multiple traces is also useful for [model-based testing](https://mbt.informal.systems/docs/modelator.html), where the goal is to use a model to generate tests for a software implementation of the system.
 

--- a/jekyll/docs/tla_basics_tutorials/hello_world.md
+++ b/jekyll/docs/tla_basics_tutorials/hello_world.md
@@ -199,7 +199,7 @@ BobCheckInbox ==
     /\ \/ /\ bobs_mood' = "happy"
           /\ bobs_inbox = <<"hello", "world">>
        \/ /\ bobs_mood' = "neutral"
-          /\ bobs_inbox # <<"hello", "world">>
+          /\ bobs_inbox /= <<"hello", "world">>
     /\ UNCHANGED <<network, bobs_inbox, alices_outbox>> 
 ```
 
@@ -307,7 +307,7 @@ State 6: <..>
 /\ bobs_mood = "happy"
 ```
 
-Notice that bob is happy in state 8.
+Notice that bob is happy in state 6.
 
 ## Wrapping up
 

--- a/jekyll/docs/tla_basics_tutorials/models/hello_world_typed/hello_world_typed.cfg
+++ b/jekyll/docs/tla_basics_tutorials/models/hello_world_typed/hello_world_typed.cfg
@@ -2,4 +2,4 @@ INIT Init
 NEXT Next
 
 INVARIANTS
-NotEverythingWasLost
+NotBobIsHappy

--- a/jekyll/docs/tla_basics_tutorials/typechecking.md
+++ b/jekyll/docs/tla_basics_tutorials/typechecking.md
@@ -43,10 +43,10 @@ We have specified that
 
 1. _alices_outbox_ is a set of strings
 2. _network_ is a set of strings
-3. _bobs_moods_ is a string
+3. _bobs_mood_ is a string
 4. _bobs_inbox_ is a sequence of strings
 
-We should also specify the type of operators. For example we can annotate AliceSend(m)
+We can also specify the type of operators. For example we can annotate AliceSend(m)
 
 ```tla
 \* @type: (Str) => Bool;
@@ -58,6 +58,7 @@ AliceSend(m) ==
 ```
 
 The annotation says that AliceSend is an operator taking strings and returning booleans.
+(Note that very often the typechecker can infer annotations for operators automatically. It is able to do so for the operator AliceSend, too. You can try typechecking with the manual annotation left out.)
 
 Finally we can typecheck the model
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## Description


This is a trivial PR that fixes typos and introduces small changes.
List of changes:
 - typos
 - I replaced the inequality operator `#` for the inequality operator `/=` (the one that is mentioned in the cheat sheet)
 - I made the tutorial text consistent with the model checker results (bob is happy at state 6, and not 8)
 - I changed the invariant in `hello_world_typed.cfg`. The previous one was referring to an invariant that was not defined.
 - I added a clarification sentence about typechecker being sometimes able to infer types of operators


______

For contributor use:

- [ n/a] If applicable, unit tests are written and added to CI.
- [ n/a] Ran `go fmt`, `cargo fmt` and etc. (or had formatting run automatically on all files edited)
- [ +] Updated relevant documentation (`docs/`) and code comments.
- [ n/a: because this is a small pass over the tutorial, there should be no issue related with it] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [+ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ n/a: because this is a small pass over the tutorial, it should not be included in the changelog] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
