### PR TITLE
Fix racey bug at TLC execution

### DIFF
--- a/.changelog/unreleased/bug-fixes/rust/152-148-fix-concurrent-tlc.md
+++ b/.changelog/unreleased/bug-fixes/rust/152-148-fix-concurrent-tlc.md
@@ -1,0 +1,1 @@
+Fix concurrent TLC execution.

--- a/rs/modelator/src/model/checker/tlc/mod.rs
+++ b/rs/modelator/src/model/checker/tlc/mod.rs
@@ -120,6 +120,10 @@ fn test_cmd<P: AsRef<Path>>(
             ]
             .join(path_seperator_char),
         )
+        .arg(format!(
+            "-Djava.io.tmpdir={}",
+            temp_dir.path().to_string_lossy()
+        ))
         // set tla file
         .arg("tlc2.TLC")
         .arg(tla_file.as_ref())


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #148
Closes: #149
Closes: #150

## Description

The change makes sure, the TLA+ standard modules are extracted in unique directory for each different TLC executions, avoiding racey file access.

Fixes the mbt test failures at [`informalsystems/ibc-rs`](https://github.com/informalsystems/ibc-rs/runs/4459991158?check_suite_focus=true).
______

For contributor use:

- [ ] ~If applicable, unit tests are written and added to CI.~ (NA)
- [x] Ran `go fmt`, `cargo fmt` and etc. (or had formatting run automatically on all files edited)
- [ ] ~Updated relevant documentation (`docs/`) and code comments.~ (NA)
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
