### PR TITLE
Parse ranged set from TLA state

### DIFF
--- a/.changelog/unreleased/rust/157-support-ranged-set.md
+++ b/.changelog/unreleased/rust/157-support-ranged-set.md
@@ -1,0 +1,1 @@
+- Parse ranged sets from TLA states. (#157)

--- a/rs/modelator/src/model/language/tla/json/parser.rs
+++ b/rs/modelator/src/model/language/tla/json/parser.rs
@@ -53,6 +53,7 @@ fn parse_any_value(i: &str) -> IResult<&str, JsonValue> {
         alt((
             parse_bool,
             parse_function,
+            parse_range,
             parse_number,
             parse_string,
             parse_identifiers_as_values,
@@ -100,6 +101,19 @@ fn parse_string(i: &str) -> IResult<&str, JsonValue> {
     map(
         delimited(char('"'), cut(take_while(|c| c != '"')), char('"')),
         |value: &str| JsonValue::String(value.into()),
+    )(i)
+}
+
+fn parse_range(i: &str) -> IResult<&str, JsonValue> {
+    map(
+        separated_pair(parse_number, tag(".."), parse_number),
+        |(low, high)| {
+            JsonValue::Array(
+                (low.as_i64().unwrap()..=high.as_i64().unwrap())
+                    .map(|x| JsonValue::Number(x.into()))
+                    .collect(),
+            )
+        },
     )(i)
 }
 

--- a/rs/modelator/src/model/language/tla/json/parser.rs
+++ b/rs/modelator/src/model/language/tla/json/parser.rs
@@ -295,7 +295,7 @@ mod tests {
 
     const fn booleans_and_numbers_state_without_first_logical_and() -> &'static str {
         r#"
-            empty_set = {} /\ set = {1, 2, 3} /\ pos_number = 1 /\ neg_number = -1 /\ bool = TRUE
+            empty_set = {} /\ set = {1, 2, 3} /\ ranged_set = 1..5 /\ pos_number = 1 /\ neg_number = -1 /\ bool = TRUE
         "#
     }
 
@@ -303,6 +303,7 @@ mod tests {
         r#"
             /\ empty_set = {}
             /\ set = {1, 2, 3}
+            /\ ranged_set = 1..5
             /\ pos_number = 1
             /\ neg_number = -1
             /\ bool = TRUE
@@ -313,6 +314,7 @@ mod tests {
         json!({
             "empty_set": [],
             "set": [1, 2, 3],
+            "ranged_set": [1, 2, 3, 4, 5],
             "pos_number": 1,
             "neg_number": -1,
             "bool": true
@@ -323,6 +325,7 @@ mod tests {
         r#"
             /\ empty_set = {}
             /\ set = {1, 2, 3}
+            /\ ranged_set = 1..5
             /\ pos_number = 1
             /\ neg_number = -1
             /\ bool = TRUE
@@ -333,6 +336,7 @@ mod tests {
         json!({
             "empty_set": [],
             "set": [1, 2, 3],
+            "ranged_set": [1, 2, 3, 4, 5],
             "pos_number": 1,
             "neg_number": -1,
             "bool": true


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #156 

## Description

Adds support for parsing TLA states with ranges set.

```
a = 1..10
```

______

For contributor use:

- [x] If applicable, unit tests are written and added to CI.
- [x] Ran `go fmt`, `cargo fmt` and etc. (or had formatting run automatically on all files edited)
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).

N/A:

- ~Updated relevant documentation (`docs/`) and code comments.~
