### PR TITLE
Adds golang c bindings for aarch64-apple-darwin

### DIFF
--- a/golang/steprunner.go
+++ b/golang/steprunner.go
@@ -3,6 +3,7 @@ package modelator
 /*
 #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../target/x86_64-unknown-linux-gnu/release -lmodelatorc -ldl -lm
 #cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/../target/x86_64-apple-darwin/release -lmodelatorc -framework Security
+#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../target/aarch64-apple-darwin/release -lmodelatorc -framework Security
 #cgo windows,amd64 LDFLAGS: -L${SRCDIR}/../target/x86_64-pc-windows-gnu/release -lmodelatorc -lws2_32 -lole32 -luserenv -lbcrypt
 #cgo CFLAGS: -I${SRCDIR}/../rust/ffi/src
 #include <lib.h>


### PR DESCRIPTION
Closes: #155

## Description

Builds go bindings aarch64 darwin.

Fixes https://github.com/informalsystems/modelator/issues/155

______

For contributor use:

- [x] If applicable, unit tests are written and added to CI.
- [ ] Ran `go fmt`, `cargo fmt` and etc. (or had formatting run automatically on all files edited)
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
