### PR TITLE
removed TLC as an option

### DIFF
--- a/ModelatorShell.md
+++ b/ModelatorShell.md
@@ -44,7 +44,7 @@ If run without arguments, it will assume the default arguments:
 - and that the checker is `apalache`
 
 We could suply each of these arguments individually, for instance
-`m.check(invariants=['Inv', 'Inv2'], checker='tlc')`.
+`m.check(invariants=['Inv', 'Inv2'], checker='apalache')`.
 The output is
 
 ```

--- a/jars/apalache.jar
+++ b/jars/apalache.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14dee246bff93d76d6fbf5d66b68cfa744aac7bd3692653c719d71afdd779c8e
+size 73073621

--- a/modelator/Model.py
+++ b/modelator/Model.py
@@ -184,6 +184,11 @@ class Model:
         checker_params: Dict = None,
     ) -> ModelResult:
 
+        if checker is not const_values.APALACHE:
+            raise ValueError(
+                "Currently, only the Apalache checker is supported. Support for TLC coming soon"
+            )
+
         if self.parsable is False:
             raise self.last_parsing_error
         checking_constants = self.model_constants

--- a/modelator/const_values.py
+++ b/modelator/const_values.py
@@ -2,7 +2,7 @@
 APALACHE = "apalache"
 TLC = "tlc"
 
-DEFAULT_APALACHE_JAR = "jars/apalache-pkg-0.25.0.jar"
+DEFAULT_APALACHE_JAR = "jars/apalache.jar"
 DEFAULT_TLC_JAR = "jars/tla2tools-v1.8.0.jar"
 
 PARSE = "parse"
@@ -26,4 +26,4 @@ CONFIG = "config"
 SHELL_ACTIVE = False
 
 
-CHECKER_TIMEOUT=60
+CHECKER_TIMEOUT = 60

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -46,9 +46,9 @@ def test_check():
         config_file_name=config_name,
         check_f=check_apalache,
     )
-    _matchingCheckValue(
-        invariant_holds, True, True, config_file_name=config_name, check_f=check_tlc
-    )
+    # _matchingCheckValue(
+    #     invariant_holds, True, True, config_file_name=config_name, check_f=check_tlc
+    # )
 
     # _matchingCheckValue(invariant_holds, True, True, apalache_args=args)
 
@@ -70,10 +70,10 @@ def test_check():
         check_f=check_apalache,
     )
 
-    _matchingCheckValue(
-        invariant_does_not_hold,
-        False,
-        False,
-        config_file_name=config_name,
-        check_f=check_tlc,
-    )
+    # _matchingCheckValue(
+    #     invariant_does_not_hold,
+    #     False,
+    #     False,
+    #     config_file_name=config_name,
+    #     check_f=check_tlc,
+    # )


### PR DESCRIPTION
Removing the support for TLC (raising an exception if anything other than the default, 'apalache' option is given).

When running tests, I understood I did something wrong when adding jars to `git-lfs` ([this commit](https://github.com/informalsystems/modelator/commit/baf60c17a18ea9b2057af71eee858f0aa6d2ed37)) - probably I am not using it correctly.

However, since we are anyways doing this in a different way with issue #212, I only added a workaround for now (by adding one full jar file)