### PR TITLE
Split CLI command `check-apalache-jar` into `apalache get` and `apalache info`

### DIFF
--- a/modelator/cli/__init__.py
+++ b/modelator/cli/__init__.py
@@ -293,7 +293,7 @@ def reset():
 
 app_apalache = typer.Typer(
     name="apalache",
-    help="Apalache JAR",
+    help="Apalache: check whether the JAR file is locally available or download it.",
     no_args_is_help=True,
     add_completion=False,
     rich_markup_mode="rich",

--- a/modelator/cli/__init__.py
+++ b/modelator/cli/__init__.py
@@ -302,23 +302,25 @@ app.add_typer(app_apalache, name="apalache")
 
 
 @app_apalache.command()
-def check(
+def info(
     version: Optional[str] = typer.Argument(
         const_values.DEFAULT_APALACHE_VERSION, help=f"Apalache's version."
     ),
 ):
     """
-    Check which version of Apalache is installed.
+    Display whether Apalache is installed and information about it.
     """
+    print(f"Default location for JAR file: {const_values.DEFAULT_CHECKERS_LOCATION}")
+    print(f"Looking for version: {version}")
     jar_path = apalache_jar.apalache_jar_build_path(
         const_values.DEFAULT_CHECKERS_LOCATION, version
     )
+    print(f"Looking for file: {jar_path}")
     if apalache_jar.apalache_jar_exists(jar_path, version):
-        print(f"Apalache jar file exists at {jar_path}")
         existing_version = apalache_jar.apalache_jar_version(jar_path)
-        print(f"Apalache jar version: {existing_version}")
+        print(f"Apalache JAR file exists and its version is {existing_version}")
     else:
-        print(f"Apalache jar file not found at {jar_path}")
+        print(f"Apalache JAR file not found")
 
 
 @app_apalache.command()

--- a/modelator/cli/__init__.py
+++ b/modelator/cli/__init__.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import typer
 from timeit import default_timer as timer
 from typing import List, Optional
 
@@ -292,14 +291,24 @@ def reset():
         print(f"Model file removed")
 
 
-@app.command()
-def check_apalache_jar(
+app_apalache = typer.Typer(
+    name="apalache",
+    help="Apalache JAR",
+    no_args_is_help=True,
+    add_completion=False,
+    rich_markup_mode="rich",
+)
+app.add_typer(app_apalache, name="apalache")
+
+
+@app_apalache.command()
+def check(
     version: Optional[str] = typer.Argument(
         const_values.DEFAULT_APALACHE_VERSION, help=f"Apalache's version."
     ),
 ):
     """
-    Check whether Apalache's uber jar file is installed, or download it otherwise.
+    Check which version of Apalache is installed.
     """
     jar_path = apalache_jar.apalache_jar_build_path(
         const_values.DEFAULT_CHECKERS_LOCATION, version
@@ -310,13 +319,27 @@ def check_apalache_jar(
         print(f"Apalache jar version: {existing_version}")
     else:
         print(f"Apalache jar file not found at {jar_path}")
-        print(f"Will attempt to download version {version}...")
-        try:
-            apalache_jar.apalache_jar_download(
-                download_location=const_values.DEFAULT_CHECKERS_LOCATION,
-                expected_version=version,
-            )
-            print("Done ✅")
-            print(f"Apalache jar file: {jar_path}")
-        except ValueError as e:
-            print(f"ERROR: {e}")
+
+
+@app_apalache.command()
+def get(
+    version: Optional[str] = typer.Argument(
+        const_values.DEFAULT_APALACHE_VERSION, help=f"Apalache's version."
+    ),
+):
+    """
+    Download Apalache jar file.
+    """
+    jar_path = apalache_jar.apalache_jar_build_path(
+        const_values.DEFAULT_CHECKERS_LOCATION, version
+    )
+    print(f"Downloading Apalache version {version}")
+    try:
+        apalache_jar.apalache_jar_download(
+            download_location=const_values.DEFAULT_CHECKERS_LOCATION,
+            expected_version=version,
+        )
+        print("Done ✅")
+        print(f"Apalache jar file: {jar_path}")
+    except ValueError as e:
+        print(f"ERROR: {e}")


### PR DESCRIPTION
Currently the command `check-apalache-jar` checks if an Apalache jar file is installed. If not it downloads a version of the file. This PR replaces `check-apalache-jar` by the `apalache` command that includes two subcommands: `check` and `get`.
