### PR TITLE
Ivan/timestamped traces folders

### DIFF
--- a/modelator/checker/check.py
+++ b/modelator/checker/check.py
@@ -95,12 +95,9 @@ def check_apalache(
     check_logger.debug(f"command: {json.dumps(json_command, indent=4, sort_keys=True)}")
     result = apalache_pure(json=json_command)
 
-    if traces_dir:
-        trace_paths = apalache_helpers.write_trace_files_to(result, traces_dir)
-        for trace_path in trace_paths:
-            check_logger.info(f"Wrote trace file to {trace_path}")
-    else:
-        trace_paths = []
+    trace_paths = apalache_helpers.write_trace_files_to(result, traces_dir)
+    for trace_path in trace_paths:
+        check_logger.info(f"Wrote trace file to {trace_path}")
 
     if result["return_code"] == 0:
         return CheckResult(True, trace_paths=trace_paths)

--- a/modelator/checker/check.py
+++ b/modelator/checker/check.py
@@ -95,9 +95,12 @@ def check_apalache(
     check_logger.debug(f"command: {json.dumps(json_command, indent=4, sort_keys=True)}")
     result = apalache_pure(json=json_command)
 
-    trace_paths = apalache_helpers.write_trace_files_to(result, traces_dir)
-    for trace_path in trace_paths:
-        check_logger.info(f"Wrote trace file to {trace_path}")
+    if traces_dir:
+        trace_paths = apalache_helpers.write_trace_files_to(result, traces_dir)
+        for trace_path in trace_paths:
+            check_logger.info(f"Wrote trace file to {trace_path}")
+    else:
+        trace_paths = []
 
     if result["return_code"] == 0:
         return CheckResult(True, trace_paths=trace_paths)

--- a/modelator/cli/__init__.py
+++ b/modelator/cli/__init__.py
@@ -1,4 +1,6 @@
+import os
 from pathlib import Path
+import time
 from timeit import default_timer as timer
 import typer
 from typing import Dict, List, Optional
@@ -177,7 +179,7 @@ def check(
         None, help="List of invariants to check (overwrites config file)."
     ),
     traces_dir: Optional[str] = typer.Option(
-        const_values.DEFAULT_TRACES_DIR,
+        default=None,
         help="Path to store generated trace files (overwrites config file).",
     ),
 ):
@@ -187,6 +189,11 @@ def check(
     If extra options are provided, they will be passed directly to the model-checker,
     overwriting values in the config file.
     """
+
+    if traces_dir is None:
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+        traces_dir = os.path.join(const_values.DEFAULT_TRACES_DIR, timestamp)
+
     model, config = _load_model_with_arguments(
         "check",
         invariants,

--- a/modelator/utils/apalache_helpers.py
+++ b/modelator/utils/apalache_helpers.py
@@ -1,7 +1,6 @@
 import json
 import os
 import re
-import time
 from pathlib import Path
 from typing import Dict, List
 

--- a/modelator/utils/apalache_helpers.py
+++ b/modelator/utils/apalache_helpers.py
@@ -26,11 +26,8 @@ def write_trace_files_to(apalache_result: Dict, traces_dir: str) -> List[str]:
 
     trace_paths = []
     for filename in itfs_filenames:
-        # Build full file path, with a timestamp in its name
-        name, _, extension = filename.partition(".")
-        timestamp = time.strftime("%Y%m%d-%H%M%S")
-        new_filename = f"{name}_{timestamp}.{extension}"
-        path = os.path.join(traces_dir, new_filename)
+
+        path = os.path.join(traces_dir, filename)
 
         if Path(path).is_file():
             print(f"WARNING: existing file will be overwritten: {path}")


### PR DESCRIPTION
Closes: #252 

## Description

 - I set the default value to `traces-dir` in CLI to `None`. The if it is `None`, I set its value to `traces/<timestamp>`
 - I removed the logic that was adding timestamp to the traces file name from the `apalache_helpers:check`