### PR TITLE
Add timestamp to `traces_dir` when checking and sampling

### DIFF
--- a/modelator/cli/__init__.py
+++ b/modelator/cli/__init__.py
@@ -179,7 +179,7 @@ def check(
         None, help="List of invariants to check (overwrites config file)."
     ),
     traces_dir: Optional[str] = typer.Option(
-        default=None,
+        None,
         help="Path to store generated trace files (overwrites config file).",
     ),
 ):
@@ -223,7 +223,7 @@ def sample(
         help="Model operators describing desired properties in the final state of the execution (overwrites config file).",
     ),
     traces_dir: Optional[str] = typer.Option(
-        const_values.DEFAULT_TRACES_DIR,
+        None,
         help="Path to store generated trace files (overwrites config file).",
     ),
 ):
@@ -325,7 +325,7 @@ def _load_model_with_arguments(
     else:
         raise ValueError("Unknown checker mode")
 
-    if traces_dir is None:
+    if not traces_dir:
         timestamp = time.strftime("%Y%m%d-%H%M%S")
         traces_dir = os.path.join(const_values.DEFAULT_TRACES_DIR, timestamp)
 

--- a/modelator/cli/__init__.py
+++ b/modelator/cli/__init__.py
@@ -189,11 +189,6 @@ def check(
     If extra options are provided, they will be passed directly to the model-checker,
     overwriting values in the config file.
     """
-
-    if traces_dir is None:
-        timestamp = time.strftime("%Y%m%d-%H%M%S")
-        traces_dir = os.path.join(const_values.DEFAULT_TRACES_DIR, timestamp)
-
     model, config = _load_model_with_arguments(
         "check",
         invariants,
@@ -329,6 +324,10 @@ def _load_model_with_arguments(
         properties_config_name = "examples"
     else:
         raise ValueError("Unknown checker mode")
+
+    if traces_dir is None:
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+        traces_dir = os.path.join(const_values.DEFAULT_TRACES_DIR, timestamp)
 
     config, config_from_arguments = _load_config_and_merge_arguments(
         config_path,

--- a/tests/cli/model/Test3.tla
+++ b/tests/cli/model/Test3.tla
@@ -1,0 +1,11 @@
+---- MODULE Test3 ----
+EXTENDS Integers
+VARIABLE
+    \* @type: Int;
+    x
+Init == x = 0
+Next == x' = x + 1
+Inv == x \in Nat
+Inv2 == x' > x
+ThreeSteps == x = 3
+======================

--- a/tests/cli/test_sample.md
+++ b/tests/cli/test_sample.md
@@ -1,6 +1,6 @@
 # Test the `sample` command
 
-Run `sample` without specifying a model or a property to check should fail:
+Running `sample` without specifying a model or a property to check should fail:
 
 ```sh
 $ modelator sample
@@ -8,7 +8,7 @@ $ modelator sample
 [1]
 ```
 
-Run `sample` without specifying a model should fail:
+Running `sample` without specifying a model should fail:
 
 ```sh
 $ modelator sample --examples=ThreeSteps
@@ -16,7 +16,7 @@ $ modelator sample --examples=ThreeSteps
 [1]
 ```
 
-Run `sample` with a non existing config file should fail:
+Running `sample` with a non existing config file should fail:
 
 ```sh
 $ modelator sample --config-path non-existing-file
@@ -24,13 +24,40 @@ ERROR: config file not found
 [4]
 ```
 
-Run `sample` with ...:
+Running `sample` with a model and a property to sample should succeed:
 
 ```sh
 $ modelator sample --model-path model/Test3.tla --examples ThreeSteps
 ...
 - ThreeSteps OK ✅
 ...
+```
+
+Check that the number and length of the generated trace files is as expected:
+
+```sh
+$ ./traces_num_generated.sh
+1
+$ ./traces_last_generated.sh | xargs -I {} ./traces_length.sh {}
+3
+```
+
+Running `sample` with a model and a property to sample should succeed and generate 3 trace files:
+
+```sh
+$ modelator sample --model-path model/Test3.tla --examples ThreeSteps --max_error=3
+...
+- ThreeSteps OK ✅
+...
+```
+
+Check that the number and length of the generated trace files is as expected:
+
+```sh
+$ ./traces_num_generated.sh
+3
+$ ./traces_last_generated.sh | xargs -I {} ./traces_length.sh {}
+3
 ```
 
 Running `sample` on a property that is not defined in the model should fail:

--- a/tests/cli/test_sample.md
+++ b/tests/cli/test_sample.md
@@ -1,0 +1,44 @@
+# Test the `sample` command
+
+Run `sample` without specifying a model or a property to check should fail:
+
+```sh
+$ modelator sample
+...
+[1]
+```
+
+Run `sample` without specifying a model should fail:
+
+```sh
+$ modelator sample --examples=ThreeSteps
+...
+[1]
+```
+
+Run `sample` with a non existing config file should fail:
+
+```sh
+$ modelator sample --config-path non-existing-file
+ERROR: config file not found
+[4]
+```
+
+Run `sample` with ...:
+
+```sh
+$ modelator sample --model-path model/Test3.tla --examples ThreeSteps
+...
+- ThreeSteps OK ✅
+...
+```
+
+Running `sample` on a property that is not defined in the model should fail:
+
+```sh
+$ modelator sample --model-path model/Test3.tla --examples=NonExistingProperty
+...
+ERROR: NonExistingProperty not defined in the model
+...
+[3]
+```

--- a/tests/cli/traces_last_generated.sh
+++ b/tests/cli/traces_last_generated.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# See https://sipb.mit.edu/doc/safe-shell/
+set -eu -o pipefail
+
+TRACES_DIR="${1:-traces}"
+
+TIMESTAMP_SUBDIR=$(ls -rt $TRACES_DIR | tail -1)
+
+# last file in the directory by time
+LAST_FILE=$(ls -rt $TRACES_DIR/$TIMESTAMP_SUBDIR | tail -1)
+
+echo $TRACES_DIR/$TIMESTAMP_SUBDIR/$LAST_FILE

--- a/tests/cli/traces_length.sh
+++ b/tests/cli/traces_length.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# See https://sipb.mit.edu/doc/safe-shell/
+set -eu -o pipefail
+
+TRACE_FILE="$1"
+
+[ -z $TRACE_FILE ] && echo -e "ERROR: invalid arguments\nUsage: $0 <TRACE_FILE>" && exit 1
+
+[ ! -f $TRACE_FILE ] && echo -e "ERROR: file $TRACE_FILE does not exists" && exit 1
+
+TRACE_LENGTH=$(cat $TRACE_FILE | jq '.states[]."#meta".index' | tail -1)
+echo $TRACE_LENGTH

--- a/tests/cli/traces_num_generated.sh
+++ b/tests/cli/traces_num_generated.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# See https://sipb.mit.edu/doc/safe-shell/
+set -eu -o pipefail
+
+TRACES_DIR="${1:-traces}"
+
+TIMESTAMP_SUBDIR=$(ls -rt $TRACES_DIR | tail -1)
+DIR=$TRACES_DIR/$TIMESTAMP_SUBDIR
+
+# Return the number of files in the directory
+# - tail -n+2 for discarding the first file (violation.itf.json)
+# - xargs for trimming whitespace
+TRACE_FILES=$(ls -rt $DIR | tail -n+2 | wc -l | xargs)
+echo $TRACE_FILES


### PR DESCRIPTION
Closes: #259

The fix the code is simple. This PR also adds an mdx test to check the number of generated files and the length of those files.