### PR TITLE
Catch apalache error messages for uninitialized constants and config problems

### DIFF
--- a/modelator/Model.py
+++ b/modelator/Model.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 import threading
 from copy import copy
 from typing import Any, Dict, List, Optional, Union
@@ -91,22 +92,22 @@ class Model:
         constants,
         checker,
         tla_file_name,
-        checking_files_content,
+        files,
         checker_params,
         traces_dir,
     ):
         args = checker_params
         if const_values.CONFIG not in args or not args[const_values.CONFIG]:
-            config_file_name = "generated_config.cfg"
+            args[const_values.CONFIG] = Path(tla_file_name).name.replace(".tla", ".cfg")
+
+        if args[const_values.CONFIG] not in files:
             config_file_content = tla_helpers.build_config_file_content(
                 init=self.init_predicate,
                 next=self.next_predicate,
                 invariants=predicates,
                 constants=constants,
             )
-
-            args[const_values.CONFIG] = config_file_name
-            checking_files_content[config_file_name] = config_file_content
+            files[args[const_values.CONFIG]] = config_file_content
 
         if checker == const_values.TLC:
             check_func = check_tlc
@@ -114,12 +115,7 @@ class Model:
             check_func = check_apalache
 
         try:
-            result = check_func(
-                tla_file_name=tla_file_name,
-                files=checking_files_content,
-                args=args,
-                traces_dir=traces_dir,
-            )
+            result = check_func(tla_file_name, files, args, traces_dir)
         except Exception as e:
             self.logger.error("Problem running {}: {}".format(checker, e))
             raise ModelCheckingError(e)
@@ -132,7 +128,7 @@ class Model:
         constants,
         checker,
         tla_file_name,
-        checking_files_content,
+        files,
         checker_params,
         mod_res,
         monitor_update_functions,
@@ -148,7 +144,7 @@ class Model:
             constants=constants,
             checker=checker,
             tla_file_name=tla_file_name,
-            checking_files_content=checking_files_content,
+            files=files,
             checker_params=checker_params,
             traces_dir=traces_dir,
         )
@@ -162,6 +158,7 @@ class Model:
             mod_res._successful.append(original_predicate_name)
         else:
             mod_res._unsuccessful.append(original_predicate_name)
+            mod_res.operator_errors[original_predicate_name] = check_result.error_msg
 
         mod_res.lock.release()
 
@@ -215,7 +212,7 @@ class Model:
                     "constants": constants,
                     "checker": checker,
                     "tla_file_name": self.tla_file_path,
-                    "checking_files_content": copy(self.files_contents),
+                    "files": copy(self.files_contents),
                     "checker_params": checker_params,
                     "mod_res": mod_res,
                     "monitor_update_functions": [
@@ -288,7 +285,7 @@ class Model:
                     "constants": constants,
                     "checker": checker,
                     "tla_file_name": negated_name,
-                    "checking_files_content": sampling_files_content,
+                    "files": sampling_files_content,
                     "checker_params": checker_params,
                     "mod_res": mod_res,
                     "monitor_update_functions": [

--- a/modelator/checker/CheckResult.py
+++ b/modelator/checker/CheckResult.py
@@ -1,13 +1,14 @@
 from typing import List, Optional
-
 from tomlkit import boolean
+
+from modelator.utils.ErrorMessage import ErrorMessage
 
 
 class CheckResult:
     def __init__(
         self,
         is_ok: boolean,
-        error_msg: Optional[str] = None,
+        error_msg: Optional[ErrorMessage] = None,
         traces: List[str] = [],
         trace_paths: List[str] = [],
     ) -> None:

--- a/modelator/cli/__init__.py
+++ b/modelator/cli/__init__.py
@@ -53,28 +53,6 @@ def _create_and_parse_model(model_path: str, init="Init", next="Next", constants
     return model
 
 
-def _print_results(result: ModelResult):
-    print("Results:")
-    for op in result.inprogress():
-        print(f"- {op} ⏳")
-    for op in result.successful():
-        print(f"- {op} OK ✅")
-        trace = result.traces(op)
-        if trace:
-            print(f"    Trace: {trace}")
-        trace_paths = result.trace_paths(op)
-        if trace_paths:
-            print(f"    Trace files: {trace_paths}")
-    for op in result.unsuccessful():
-        print(f"- {op} FAILED ❌")
-        trace = result.traces(op)
-        if trace:
-            print(f"    Trace: {trace}")
-        trace_paths = result.trace_paths(op)
-        if trace_paths:
-            print(f"    Trace files: {trace_paths}")
-
-
 @app.command()
 def load(
     path: str = typer.Argument(..., help="Path to a TLA+ model file."),
@@ -403,13 +381,13 @@ def _run_checker(mode, model, config):
 
     start_time = timer()
     print("{} {}... ".format(action, ", ".join(config[properties_config_name])))
-    result = handler(
+    result: ModelResult = handler(
         config[properties_config_name],
         constants=config["constants"],
         checker_params=config["params"],
         traces_dir=config["traces_dir"],
     )
-    _print_results(result)
+    print(f"Results:\n{result}")
     print(f"Total time: {(timer() - start_time):.2f} seconds")
 
 

--- a/modelator/utils/ErrorMessage.py
+++ b/modelator/utils/ErrorMessage.py
@@ -1,24 +1,33 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
 class ErrorMessage:
     problem_description: str
-    location: int = None
+    location: Optional[int] = None
     full_error_msg: str = ""
     file_path: str = ""
     error_category: str = ""
 
     def __str__(self) -> str:
-        if self.location is not None:
+        if self.location:
             locationInfo = ":" + str(self.location)
         else:
             locationInfo = ""
-        error_message = "{kind} error at {path}{lineNum}:\n{errorContent}".format(
-            kind=self.error_category.capitalize(),
-            path=self.file_path,
-            lineNum=locationInfo,
-            errorContent=self.problem_description,
-        )
 
-        return error_message
+        kind = self.error_category.capitalize()
+        location = f"{self.file_path}{locationInfo}"
+
+        s = ""
+        if kind:
+            s += f"{kind} error"
+        if location:
+            if not kind:
+                s += "error"
+            s += f" at {location}"
+        if s:
+            s += ":\n"
+        s += self.problem_description
+
+        return s

--- a/tests/cli/test_constants.md
+++ b/tests/cli/test_constants.md
@@ -1,0 +1,55 @@
+# Tests on instantiation of model constants
+
+First, make sure that there is no model loaded:
+
+```sh
+$ modelator reset
+...
+```
+
+Load a model that declares some constant:
+
+```sh
+$ modelator load model/Test2.tla
+...
+Loading OK ✅
+```
+
+Running `check` on the loaded model, without initializing constants, should fail
+with an error message:
+
+```sh
+$ modelator check --invariants Inv
+...
+- Inv FAILED ❌
+    A constant in the model is not initialized
+...
+```
+
+Running `check` on the loaded model passing `invariants` and valid `constants`
+should succeed:
+
+```sh
+$ modelator check --invariants Inv --constants X=InstanceX
+...
+- Inv OK ✅
+...
+```
+
+Running `check` on the loaded model passing `invariants` and invalid `constants`
+should fail:
+
+```sh
+$ modelator check --invariants Inv --constants X=AnUndefinedIdentifier
+...
+- Inv FAILED ❌
+    Configuration error:
+...
+```
+
+Finally, clean the generated files after the test:
+
+```sh
+$ modelator reset
+Model file removed
+```

--- a/tests/cli/trace_check.sh
+++ b/tests/cli/trace_check.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# See https://sipb.mit.edu/doc/safe-shell/
+set -eu -o pipefail
+
+PREFIX="${1:-violation}"
+TRACES_DIR="${2:-traces}"
+
+TRACE_FILE=$(./trace_find.sh $PREFIX $TRACES_DIR)
+echo "Trace file: $TRACE_FILE"
+
+TRACE_LENGTH=$(./trace_length.sh $TRACE_FILE)
+echo "Trace length: $TRACE_LENGTH"


### PR DESCRIPTION
Currently Modelator raises an exception when the model contains constants that are not instantiated or when there are similar problems in the TLA+ config file. Apalache fails but Modelator does not capture those error messages. This PR tries to solve that by displaying more user-friendly error messages.