### PR TITLE
Remove extra trace file generated during simulation

### DIFF
--- a/modelator/Model.py
+++ b/modelator/Model.py
@@ -282,8 +282,10 @@ class Model:
             cmd=const_values.SIMULATE_CMD,
         )
 
-        mod_res._simulation_traces = simulation_traces
-        mod_res._simulation_traces_paths = paths
+        # had to add [1:] because apalache simulate produces one extra trace (and I suspect
+        # that example0.itf.json and example1.itf.json are the same)
+        mod_res._simulation_traces = simulation_traces[1:]
+        mod_res._simulation_traces_paths = paths[1:]
 
         for monitor in self.monitors:
             monitor.on_simulate_finish(res=mod_res)

--- a/modelator/cli/__init__.py
+++ b/modelator/cli/__init__.py
@@ -190,8 +190,7 @@ def simulate(
 
     config["params"]["save_runs"] = True
     config["params"]["length"] = length
-    # -1 is necessary because Apalache will create one extra run: 0, 1,2,..., num_simulations
-    config["params"]["max_run"] = max_trace - 1
+    config["params"]["max_run"] = max_trace
 
     _run_checker("simulate", model, config)
 

--- a/modelator/utils/apalache_helpers.py
+++ b/modelator/utils/apalache_helpers.py
@@ -19,8 +19,9 @@ def write_trace_files_to(apalache_result: Dict, traces_dir: str) -> List[str]:
     # create directory if it does not exist
     Path(traces_dir).mkdir(parents=True, exist_ok=True)
 
+    itfs_filenames_pattern = re.compile(r"\d\.itf\.json$")
     itfs_filenames = [
-        f for f in apalache_result["files"].keys() if f.endswith(".itf.json")
+        f for f in apalache_result["files"].keys() if itfs_filenames_pattern.search(f)
     ]
     itfs_filenames.sort()
 

--- a/tests/cli/traces_num_generated.sh
+++ b/tests/cli/traces_num_generated.sh
@@ -18,5 +18,5 @@ DIR="$DIR/$TIMESTAMP_SUBDIR/$PROPERTY_NAME"
 # Return the number of files in the directory
 # - tail -n+2 for discarding the first file (violation.itf.json)
 # - xargs for trimming whitespace
-NUM_TRACE_FILES=$(ls -rt $DIR | grep .itf.json | tail -n+2 | wc -l | xargs)
+NUM_TRACE_FILES=$(ls -rt $DIR | grep .itf.json | tail -n+1 | wc -l | xargs)
 echo $NUM_TRACE_FILES


### PR DESCRIPTION
This is a follow-up PR for the [simulate command](https://github.com/informalsystems/modelator/pull/275).