### PR TITLE
Support unknown Apalache versions

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -8,6 +8,8 @@ on:
       - modelator/**
       - tests/cli/*.md
       - tests/cli/*.sh
+      - pyproject.toml
+      - poetry.lock
     branches:
       - dev
 
@@ -37,7 +39,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('**/pyproject.lock') }}
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('**/pyproject.toml') }}
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root

--- a/modelator/cli/__init__.py
+++ b/modelator/cli/__init__.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from timeit import default_timer as timer
 from typing import Dict, List, Optional
 
+import semver
 import typer
 
 from modelator import ModelResult, __version__, const_values
@@ -544,10 +545,20 @@ def apalache_info(
         print("Apalache JAR file not found")
 
 
+def version_callback(value: str):
+    try:
+        semver.parse(value)
+    except ValueError as e:
+        raise typer.BadParameter(str(e))
+    return value
+
+
 @app_apalache.command()
 def get(
     version: Optional[str] = typer.Argument(
-        const_values.DEFAULT_APALACHE_VERSION, help="Apalache's version."
+        const_values.DEFAULT_APALACHE_VERSION,
+        help="Apalache's version.",
+        callback=version_callback,
     ),
 ):
     """

--- a/modelator/const_values.py
+++ b/modelator/const_values.py
@@ -39,6 +39,10 @@ def apalache_release_url(expected_version):
     return f"https://github.com/informalsystems/apalache/releases/download/v{expected_version}/apalache.zip"
 
 
+def apalache_checksum_url(expected_version: str):
+    return f"https://github.com/informalsystems/apalache/releases/download/v{expected_version}/sha256sum.txt"
+
+
 DEFAULT_TLC_JAR = "jars/tla2tools-v1.8.0.jar"
 
 PARSE = "parse"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ typer = {extras = ["all"], version = "^0.6.1"}
 rich = "^12.5.1"
 pyrsistent = "^0.18.1"
 munch = "^2.5.0"
+semver = "^2.13.0"
 
 [tool.poetry.dev-dependencies]
 fire = "^0.4.0"


### PR DESCRIPTION
Closes: #244 

Apalache repository started offering checksums.

This PR enables checksum checks from Github releases.

Example: `modelator apalache get 0.29.2`