### PR TITLE
Terminology: examples into tests

### DIFF
--- a/modelator/Model.py
+++ b/modelator/Model.py
@@ -255,8 +255,8 @@ class Model:
         self,
         # have to keep this unused argument around bcs simulate is one of the
         # handlers (parallel to check and sample), where other handlers expect
-        # invariants/examples here
-        examples: Optional[List[str]] = None,
+        # invariants/tests here
+        tests: Optional[List[str]] = None,
         constants=None,
         checker: str = const_values.APALACHE,
         checker_params: Dict[str, str] = {},
@@ -294,7 +294,7 @@ class Model:
 
     def sample(
         self,
-        examples: Optional[List[str]] = None,
+        tests: Optional[List[str]] = None,
         constants: Dict[str, Any] = {},
         checker: str = const_values.APALACHE,
         checker_params: Dict[str, str] = {},
@@ -304,9 +304,9 @@ class Model:
         if not self.parsed_ok:
             raise self.last_parsing_error
 
-        if examples is None:
+        if tests is None:
             # take all operators that are prefixed/suffixed with Ex
-            examples = [
+            tests = [
                 str(op)
                 for op in self.operators
                 if tla_helpers._default_example_criteria(str(op))
@@ -314,13 +314,13 @@ class Model:
 
         constants = {**self.constants, **constants}
 
-        mod_res = ModelResult(model=self, all_operators=examples)
+        mod_res = ModelResult(model=self, all_operators=tests)
 
         for monitor in self.monitors:
             monitor.on_sample_start(res=mod_res)
 
         threads = []
-        for example_predicate in examples:
+        for example_predicate in tests:
             (
                 negated_name,
                 negated_content,

--- a/modelator/Model.py
+++ b/modelator/Model.py
@@ -282,10 +282,8 @@ class Model:
             cmd=const_values.SIMULATE_CMD,
         )
 
-        # had to add [1:] because apalache simulate produces one extra trace (and I suspect
-        # that example0.itf.json and example1.itf.json are the same)
-        mod_res._simulation_traces = simulation_traces[1:]
-        mod_res._simulation_traces_paths = paths[1:]
+        mod_res._simulation_traces = simulation_traces
+        mod_res._simulation_traces_paths = paths
 
         for monitor in self.monitors:
             monitor.on_simulate_finish(res=mod_res)

--- a/modelator/checker/simulate.py
+++ b/modelator/checker/simulate.py
@@ -56,13 +56,13 @@ def simulate_apalache(
 
     traces_paths = []
     if traces_dir:
-        trace_paths = apalache_helpers.write_trace_files_to(result, traces_dir)
+        trace_paths = apalache_helpers.write_trace_files_to(
+            result, traces_dir, simulate=True
+        )
         for trace_path in trace_paths:
             simulate_logger.info(f"Wrote trace file to {trace_path}")
             traces_paths.append(trace_path)
 
-    simulation_tests = apalache_helpers.extract_simulations(
-        files=result["files"], num_simulations=json_command["args"]["max_run"]
-    )
+    simulation_tests = apalache_helpers.extract_simulations(trace_paths=trace_paths)
     traces = [[ITF(state) for state in trace] for trace in simulation_tests]
     return traces, traces_paths

--- a/modelator/cli/__init__.py
+++ b/modelator/cli/__init__.py
@@ -255,7 +255,7 @@ def sample(
         None,
         help="Comma-separated list of constant definitions in the format 'name=value' (overwrites config file).",
     ),
-    examples: Optional[str] = typer.Option(
+    tests: Optional[str] = typer.Option(
         None,
         help="Comma-separated list of model predicates describing desired properties in the final state of the execution (overwrites config file).",
     ),
@@ -265,14 +265,14 @@ def sample(
     ),
 ):
     """
-    Generate execution traces that reach the state described by the `examples` properties.
+    Generate execution traces that reach the state described by the `tests` properties.
 
     If extra options are provided, they will be passed directly to the model-checker,
     overwriting values in the config file.
     """
     model, config = _load_model_with_arguments(
         "sample",
-        examples,
+        tests,
         model_path,
         config_path,
         init,
@@ -372,7 +372,7 @@ def _load_model_with_arguments(
     if mode == "check":
         properties_config_name = "invariants"
     elif mode == "sample" or mode == "simulate":
-        properties_config_name = "examples"
+        properties_config_name = "tests"
     else:
         raise ValueError("Unknown checker mode")
 
@@ -447,11 +447,11 @@ def _run_checker(mode, model, config):
     elif mode == "sample":
         handler = model.sample
         action = "Sampling"
-        properties_config_name = "examples"
+        properties_config_name = "tests"
     elif mode == "simulate":
         handler = model.simulate
         action = "Simulating"
-        properties_config_name = "examples"
+        properties_config_name = "tests"
     else:
         raise ValueError("Unknown checker mode")
 

--- a/modelator/cli/model_config_file.py
+++ b/modelator/cli/model_config_file.py
@@ -60,7 +60,7 @@ def _set_default_values(config):
         "init": "Init",
         "next": "Next",
         "invariants": [],
-        "examples": [],
+        "tests": [],
         "config_file_path": None,
         **config["Model"],
     }

--- a/modelator/monitors/html_monitor.py
+++ b/modelator/monitors/html_monitor.py
@@ -33,7 +33,7 @@ class HtmlModelMonitor(ModelMonitor):
 
     def on_sample_start(self, res: ModelResult):
         self._update_title(res)
-        self._add_section(MonitorSection.create_from("Examples", res))
+        self._add_section(MonitorSection.create_from("Tests", res))
         self.write_file()
 
     def on_sample_update(self, res: ModelResult):

--- a/modelator/monitors/markdown_monitor.py
+++ b/modelator/monitors/markdown_monitor.py
@@ -33,7 +33,7 @@ class MarkdownModelMonitor(ModelMonitor):
 
     def on_sample_start(self, res: ModelResult):
         self._update_title(res)
-        self._add_section(MonitorSection.create_from("Examples", res))
+        self._add_section(MonitorSection.create_from("Tests", res))
         self.write_file()
 
     def on_sample_update(self, res: ModelResult):

--- a/modelator/samples/HelloFull.config.toml
+++ b/modelator/samples/HelloFull.config.toml
@@ -2,7 +2,7 @@
 init = "Init"
 # next = "Next"
 invariants = ["Inv", "AlwaysEvenInvariant"]
-examples = ["ExTest", "ExFail"]
+tests = ["ExTest", "ExFail"]
 
 [Config]
 # location for the generated trace files

--- a/modelator/utils/apalache_helpers.py
+++ b/modelator/utils/apalache_helpers.py
@@ -27,9 +27,10 @@ def write_trace_files_to(
     ]
     itfs_filenames.sort()
     if simulate is True and len(itfs_filenames) > 0:
-        # had to add [1:] because apalache simulate produces one extra trace (and I suspect
-        # that example0.itf.json and example1.itf.json are the same)
-        itfs_filenames = itfs_filenames[1:]
+        # have to filter out the "example0.itf.json" because in the simulation mode and older versions
+        # of Apalache (e.g., current Modelator's default, 0.25.10), an additional examples under the name
+        # "example0.itf.json" is generated.
+        itfs_filenames = [f for f in itfs_filenames if not f == "example0.itf.json"]
 
     trace_paths = []
     for filename in itfs_filenames:

--- a/tests/cli/model/Test1.config.toml
+++ b/tests/cli/model/Test1.config.toml
@@ -2,7 +2,7 @@
 init = "Init"
 # next = "Next"
 invariants = ["Inv"]
-# examples = ["ExTest", "ExFail"]
+# tests = ["ExTest", "ExFail"]
 
 [Config]
 # location for the generated trace files

--- a/tests/cli/simulation_traces_num_generated.sh
+++ b/tests/cli/simulation_traces_num_generated.sh
@@ -12,7 +12,6 @@ DIR="$TRACES_DIR"
 
 
 # Return the number of files in the directory
-# - tail -n+2 for discarding the first file (violation.itf.json)
 # - xargs for trimming whitespace
-NUM_TRACE_FILES=$(ls -rt $DIR | grep .itf.json | tail -n+2 | wc -l | xargs)
+NUM_TRACE_FILES=$(ls -rt $DIR | grep .itf.json | tail -n+1 | wc -l | xargs)
 echo $NUM_TRACE_FILES

--- a/tests/cli/test_load_with_config.md
+++ b/tests/cli/test_load_with_config.md
@@ -34,7 +34,7 @@ Model:
 Config at model/Test1.config.toml:
 - config_file_path: None
 - constants: {}
-- examples: []
+- tests: []
 - init: Init
 - invariants: ['Inv']
 - next: Next

--- a/tests/cli/test_load_with_config.md
+++ b/tests/cli/test_load_with_config.md
@@ -34,11 +34,11 @@ Model:
 Config at model/Test1.config.toml:
 - config_file_path: None
 - constants: {}
-- tests: []
 - init: Init
 - invariants: ['Inv']
 - next: Next
 - params: {'cinit': None, 'config': None, 'length': 5, 'max_error': None, 'no_deadlock': True, 'view': None}
+- tests: []
 - traces_dir: traces/Test1
 ```
 

--- a/tests/cli/test_sample.md
+++ b/tests/cli/test_sample.md
@@ -11,7 +11,7 @@ $ modelator sample
 Running `sample` without specifying a model should fail:
 
 ```sh
-$ modelator sample --examples=ThreeSteps
+$ modelator sample --tests=ThreeSteps
 ...
 [1]
 ```
@@ -27,7 +27,7 @@ ERROR: config file not found
 Running `sample` with a model and a property to sample should succeed:
 
 ```sh
-$ modelator sample --model-path model/Test3.tla --examples ThreeSteps
+$ modelator sample --model-path model/Test3.tla --tests ThreeSteps
 ...
 - ThreeSteps OK ✅
 ...
@@ -45,7 +45,7 @@ $ ./traces_last_generated.sh ThreeSteps | xargs -I {} ./traces_length.sh {}
 Running `sample` with a model and a property to sample should succeed and generate 3 trace files:
 
 ```sh
-$ modelator sample --model-path model/Test3.tla --examples ThreeSteps --max_error=3
+$ modelator sample --model-path model/Test3.tla --tests ThreeSteps --max_error=3
 ...
 - ThreeSteps OK ✅
 ...
@@ -63,7 +63,7 @@ $ ./traces_last_generated.sh ThreeSteps | xargs -I {} ./traces_length.sh {}
 Running `sample` on a property that is not defined in the model should fail:
 
 ```sh
-$ modelator sample --model-path model/Test3.tla --examples=NonExistingProperty
+$ modelator sample --model-path model/Test3.tla --tests=NonExistingProperty
 ...
 ERROR: NonExistingProperty not defined in the model
 ...

--- a/tests/cli/traces_num_generated.sh
+++ b/tests/cli/traces_num_generated.sh
@@ -16,7 +16,6 @@ DIR="$DIR/$TIMESTAMP_SUBDIR/$PROPERTY_NAME"
 [ ! -d "$DIR" ] && echo "Directory $DIR does not exist" && exit 1
 
 # Return the number of files in the directory
-# - tail -n+2 for discarding the first file (violation.itf.json)
 # - xargs for trimming whitespace
 NUM_TRACE_FILES=$(ls -rt $DIR | grep .itf.json | tail -n+1 | wc -l | xargs)
 echo $NUM_TRACE_FILES


### PR DESCRIPTION
A rebased version of #280 
Closes: #277 
Merge together with: [Atomkraft #178](https://github.com/informalsystems/atomkraft/pull/178)

Description: 
 - changes terminology: examples are now tests
 - fixes the way the extra simulation trace was handled: now it remove `example0.itf.json`

