### PR TITLE
Update Apalache version to `0.30.x`

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+      - name: Install java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 17
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v3

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -10,8 +10,6 @@ on:
       - tests/cli/*.sh
       - pyproject.toml
       - poetry.lock
-    branches:
-      - dev
 
 jobs:
   mdx:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -63,3 +63,7 @@ jobs:
           cd tests/cli
           eval $(opam env)
           ./run-tests.sh
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 15

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -71,6 +71,11 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+      - name: Install java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 17
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v3

--- a/modelator/Model.py
+++ b/modelator/Model.py
@@ -41,12 +41,12 @@ class Model:
 
         return m
 
-    def parse(self):
+    def parse(self, args: Dict[str, str]):
 
         for monitor in self.monitors:
             monitor.on_parse_start(res=ModelResult(model=self))
         try:
-            parse(self.tla_file_path, self.files_contents)
+            parse(self.tla_file_path, self.files_contents, args)
             self.parsed_ok = True
         except ModelParsingError as e:
             self.parsed_ok = False
@@ -69,12 +69,12 @@ class Model:
             for monitor in self.monitors:
                 monitor.on_parse_finish(res=ModelResult(self, parsing_error=None))
 
-    def typecheck(self):
+    def typecheck(self, args: Dict[str, str]):
         if not self.parsed_ok:
             raise self.last_parsing_error
 
         # will raise ModelTypecheckingError if types do not match
-        typecheck(self.tla_file_path, self.files_contents)
+        typecheck(self.tla_file_path, self.files_contents, args)
 
     def instantiate(self, constants: Dict):
         self.constants = constants

--- a/modelator/Model.py
+++ b/modelator/Model.py
@@ -41,7 +41,9 @@ class Model:
 
         return m
 
-    def parse(self, args: Dict[str, str]):
+    def parse(self, args: Optional[Dict[str, str]] = None):
+        if args is None:
+            args = {}
 
         for monitor in self.monitors:
             monitor.on_parse_start(res=ModelResult(model=self))
@@ -69,7 +71,10 @@ class Model:
             for monitor in self.monitors:
                 monitor.on_parse_finish(res=ModelResult(self, parsing_error=None))
 
-    def typecheck(self, args: Dict[str, str]):
+    def typecheck(self, args: Optional[Dict[str, str]] = None):
+        if args is None:
+            args = {}
+
         if not self.parsed_ok:
             raise self.last_parsing_error
 

--- a/modelator/checker/check.py
+++ b/modelator/checker/check.py
@@ -31,7 +31,7 @@ def check_tlc(
 ) -> CheckResult:
 
     if do_parse is True:
-        parse(tla_file_name=tla_file_name, files=files)
+        parse(tla_file_name=tla_file_name, files=files, args=args)
 
     json_command = wrap_command(
         cmd=const_values.CHECK_CMD,
@@ -76,10 +76,10 @@ def check_apalache(
     check_logger.debug(f"- traces_dir: {traces_dir}")
 
     if do_parse is True:
-        parse(tla_file_name, files)
+        parse(tla_file_name, files, args)
 
     if do_typecheck is True:
-        typecheck(tla_file_name, files)
+        typecheck(tla_file_name, files, args)
 
     json_command = wrap_command(
         cmd=const_values.CHECK_CMD,

--- a/modelator/checker/simulate.py
+++ b/modelator/checker/simulate.py
@@ -29,10 +29,10 @@ def simulate_apalache(
     simulate_logger.debug(f"- traces_dir: {traces_dir}")
 
     if do_parse is True:
-        parse(tla_file_name, files)
+        parse(tla_file_name, files, args)
 
     if do_typecheck is True:
-        typecheck(tla_file_name, files)
+        typecheck(tla_file_name, files, args)
 
     json_command = wrap_command(
         cmd=cmd,

--- a/modelator/cli/__init__.py
+++ b/modelator/cli/__init__.py
@@ -43,7 +43,9 @@ def common(
     pass
 
 
-def _create_and_parse_model(model_path: str, init="Init", next="Next", constants={}):
+def _create_and_parse_model(
+    model_path: str, init="Init", next="Next", constants={}, *, args: Dict[str, str]
+):
     try:
         model = Model(model_path, init, next, constants=constants)
     except ValueError:
@@ -53,7 +55,7 @@ def _create_and_parse_model(model_path: str, init="Init", next="Next", constants
     model.files_contents = tla_helpers.get_auxiliary_tla_files(model_path)
 
     try:
-        model.parse()
+        model.parse(args=args)
     except ModelParsingError as e:
         print("Parsing error 💥")
         print(e)
@@ -62,8 +64,11 @@ def _create_and_parse_model(model_path: str, init="Init", next="Next", constants
     return model
 
 
-@app.command()
+@app.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
+)
 def load(
+    ctx: typer.Context,
     path: str = typer.Argument(..., help="Path to a TLA+ model file."),
     config_path: Optional[str] = typer.Option(
         None,
@@ -86,7 +91,9 @@ def load(
         )
 
     print(f"Loading {path}... ")
-    model = _create_and_parse_model(path)
+    extra_args = [arg[2:] for arg in ctx.args if arg.startswith("--")]
+    extra_args = _parse_list_of_assignments(extra_args)
+    model = _create_and_parse_model(path, args=extra_args)
 
     config = None
     if config_path:
@@ -101,8 +108,12 @@ def load(
     print("Loading OK ✅")
 
 
-@app.command()
-def reload():
+@app.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
+)
+def reload(
+    ctx: typer.Context,
+):
     """
     Reload model and configuration files, if any.
     """
@@ -114,7 +125,9 @@ def reload():
     model_path = model.tla_file_path
 
     print(f"Reloading {model_path}... ")
-    model = _create_and_parse_model(model_path)
+    extra_args = [arg[2:] for arg in ctx.args if arg.startswith("--")]
+    extra_args = _parse_list_of_assignments(extra_args)
+    model = _create_and_parse_model(model_path, args=extra_args)
 
     if config_path:
         print(f"Loading {config_path}... ")
@@ -128,8 +141,12 @@ def reload():
     print("Loading OK ✅")
 
 
-@app.command()
-def typecheck():
+@app.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
+)
+def typecheck(
+    ctx: typer.Context,
+):
     """
     Type check the loaded model, if available.
     """
@@ -140,7 +157,10 @@ def typecheck():
         return
 
     try:
-        model.typecheck()
+        extra_args = [arg[2:] for arg in ctx.args if arg.startswith("--")]
+        extra_args = _parse_list_of_assignments(extra_args)
+
+        model.typecheck(extra_args)
         print("Type checking OK ✅")
     except ModelTypecheckingError as e:
         print("Type checking error 💥")
@@ -396,7 +416,11 @@ def _load_model_with_arguments(
     # Load a model from a given path...
     if model_path:
         model = _create_and_parse_model(
-            model_path, config["init"], config["next"], config["constants"]
+            model_path,
+            config["init"],
+            config["next"],
+            config["constants"],
+            args=config["params"],
         )
 
     # or load a model saved in a pickle file.

--- a/modelator/cli/__init__.py
+++ b/modelator/cli/__init__.py
@@ -209,7 +209,7 @@ def simulate(
         ctx.args,
     )
 
-    config["params"]["save_runs"] = True
+    config["params"]["output_traces"] = True
     config["params"]["length"] = length
     config["params"]["max_run"] = max_trace
 

--- a/modelator/const_values.py
+++ b/modelator/const_values.py
@@ -6,7 +6,7 @@ import appdirs
 APALACHE = "apalache"
 TLC = "tlc"
 
-DEFAULT_APALACHE_VERSION = "0.25.10"
+DEFAULT_APALACHE_VERSION = "0.30.1"
 DEFAULT_CHECKERS_LOCATION = os.path.join(appdirs.user_data_dir(__package__), "checkers")
 DEFAULT_APALACHE_LOCATION = os.path.join(DEFAULT_CHECKERS_LOCATION, "apalache")
 

--- a/modelator/const_values.py
+++ b/modelator/const_values.py
@@ -54,6 +54,11 @@ CHECK_CMD = "check"
 TYPECHECK_CMD = "typecheck"
 SIMULATE_CMD = "simulate"
 
+GLOBAL_ARGS = ["features", "out_dir"]
+
+PARSE_CMD_ARGS = ["output"]
+TYPECHECK_CMD_ARGS = ["infer_poly", "output"]
+
 DEFAULT_INVARIANTS = ["Inv"]
 DEFAULT_INIT = "Init"
 DEFAULT_NEXT = "Next"

--- a/modelator/parse.py
+++ b/modelator/parse.py
@@ -8,13 +8,13 @@ from modelator.utils.model_exceptions import ModelParsingError
 from modelator.utils.modelator_helpers import wrap_command
 
 
-def parse(tla_file_name: str, files: Dict[str, str]):
+def parse(tla_file_name: str, files: Dict[str, str], args: Dict[str, str]):
     """
     Call Apalache's parser. Return nothing if ok, otherwise raise a
     ModelParsingError.
     """
 
-    json_command = wrap_command("parse", tla_file_name, files)
+    json_command = wrap_command("parse", tla_file_name, files, args=args)
     result = apalache_pure(json=json_command)
 
     if result["return_code"] != 0:

--- a/modelator/samples/AlarmClock.tla
+++ b/modelator/samples/AlarmClock.tla
@@ -3,7 +3,7 @@
 EXTENDS Naturals, Sequences
 
 VARIABLES
-  \* @typeAlias: STATE = [ hr: Int, alarmHr: Int, alarmOn: Bool ];
+  \* @typeAlias: state = { hr: Int, alarmHr: Int, alarmOn: Bool };
   \* @type: Int;
   hr,
   \* @type: Int;

--- a/modelator/samples/HourClock.tla
+++ b/modelator/samples/HourClock.tla
@@ -2,7 +2,7 @@
 
 EXTENDS Naturals, Sequences
 VARIABLES
-  \* @typeAlias: STATE = [ hr: Int ];
+  \* @typeAlias: state = { hr: Int };
   \* @type: Int;
   hr
 Init == hr \in (1..12)

--- a/modelator/samples/HourClockTraits.tla
+++ b/modelator/samples/HourClockTraits.tla
@@ -6,7 +6,7 @@ ExThreeHours == hr = 3
 
 ExHourDecrease == hr' < hr
 
-\* @type: Seq(STATE) => Bool;
+\* @type: Seq($state) => Bool;
 ExFullRun(trace) ==
     /\ Len(trace) = 12
     /\ \A s1, s2 \in DOMAIN trace:
@@ -19,7 +19,7 @@ InvNoUnderflow  == hr >= 1
 InvExThreeHours == ~ExThreeHours
 InvExHourDecrease == ~ExHourDecrease
 
-\* @type: Seq(STATE) => Bool;
+\* @type: Seq($state) => Bool;
 InvExFullRun(trace) == ~ExFullRun(trace)
 
 ==================================

--- a/modelator/typecheck.py
+++ b/modelator/typecheck.py
@@ -9,12 +9,14 @@ from modelator.utils.model_exceptions import ModelTypecheckingError
 from modelator.utils.modelator_helpers import wrap_command
 
 
-def typecheck(tla_file_name: str, files: Dict[str, str]):
+def typecheck(tla_file_name: str, files: Dict[str, str], args: Dict[str, str]):
     """
     Call Apalache's typechecker. Return nothing if ok, otherwise raise a
     ModelParsingError.
     """
-    json_command = wrap_command(const_values.TYPECHECK_CMD, tla_file_name, files)
+    json_command = wrap_command(
+        const_values.TYPECHECK_CMD, tla_file_name, files, args=args
+    )
     result = apalache_pure(json=json_command)
 
     if result["return_code"] != 0:

--- a/modelator/utils/modelator_helpers.py
+++ b/modelator/utils/modelator_helpers.py
@@ -74,6 +74,9 @@ def wrap_command(
         for arg in args:
             json_command["args"][arg] = args[arg]
 
+    if cmd in [const_values.PARSE_CMD, const_values.TYPECHECK_CMD]:
+        json_command["args"].pop("config")
+
     if checker == const_values.TLC:
         json_command["jar"] = os.path.abspath(const_values.DEFAULT_TLC_JAR)
     else:

--- a/modelator/utils/modelator_helpers.py
+++ b/modelator/utils/modelator_helpers.py
@@ -75,7 +75,8 @@ def wrap_command(
             json_command["args"][arg] = args[arg]
 
     if cmd in [const_values.PARSE_CMD, const_values.TYPECHECK_CMD]:
-        json_command["args"].pop("config")
+        if "config" in json_command["args"]:
+            json_command["args"].pop("config")
 
     if checker == const_values.TLC:
         json_command["jar"] = os.path.abspath(const_values.DEFAULT_TLC_JAR)

--- a/modelator/utils/modelator_helpers.py
+++ b/modelator/utils/modelator_helpers.py
@@ -67,21 +67,23 @@ def wrap_command(
             json_command["args"][arg] = args[arg]
 
     if cmd == const_values.PARSE_CMD:
-        for e in [
+        not_accepted_args = [
             a
             for a in json_command["args"]
             if a not in const_values.PARSE_CMD_ARGS
             and a not in const_values.GLOBAL_ARGS
-        ]:
+        ]
+        for e in not_accepted_args:
             json_command["args"].pop(e)
 
     if cmd == const_values.TYPECHECK_CMD:
-        for e in [
+        not_accepted_args = [
             a
             for a in json_command["args"]
             if a not in const_values.TYPECHECK_CMD_ARGS
             and a not in const_values.GLOBAL_ARGS
-        ]:
+        ]
+        for e in not_accepted_args:
             json_command["args"].pop(e)
 
     json_command["args"]["file"] = os.path.basename(tla_file_name)

--- a/modelator/utils/modelator_helpers.py
+++ b/modelator/utils/modelator_helpers.py
@@ -44,9 +44,6 @@ def wrap_command(
     json_command = {}
     json_command["args"] = {}
 
-    if checker == const_values.APALACHE:
-        json_command["args"]["cmd"] = cmd
-
     # TODO: come up with a more systematic way of setting defaults when they would make more sense for an end user
     # (such as here, where Apalache default for nworkers is 1) --> maybe inside shell, at the very frontend?
 
@@ -59,11 +56,6 @@ def wrap_command(
         else:
             json_command["args"]["workers"] = "auto"
 
-    json_command["args"]["file"] = os.path.basename(tla_file_name)
-
-    # send only basenames of files to modelator-py
-    json_command["files"] = {os.path.basename(f): files[f] for f in files}
-
     if cmd == const_values.CHECK_CMD:
         tla_module_name = tla_file_name.split(".")[0]
         config_file_name = tla_module_name + ".cfg"
@@ -74,14 +66,36 @@ def wrap_command(
         for arg in args:
             json_command["args"][arg] = args[arg]
 
-    if cmd in [const_values.PARSE_CMD, const_values.TYPECHECK_CMD]:
-        if "config" in json_command["args"]:
-            json_command["args"].pop("config")
+    if cmd == const_values.PARSE_CMD:
+        for e in [
+            a
+            for a in json_command["args"]
+            if a not in const_values.PARSE_CMD_ARGS
+            and a not in const_values.GLOBAL_ARGS
+        ]:
+            json_command["args"].pop(e)
+
+    if cmd == const_values.TYPECHECK_CMD:
+        for e in [
+            a
+            for a in json_command["args"]
+            if a not in const_values.TYPECHECK_CMD_ARGS
+            and a not in const_values.GLOBAL_ARGS
+        ]:
+            json_command["args"].pop(e)
+
+    json_command["args"]["file"] = os.path.basename(tla_file_name)
+
+    # send only basenames of files to modelator-py
+    json_command["files"] = {os.path.basename(f): files[f] for f in files}
 
     if checker == const_values.TLC:
         json_command["jar"] = os.path.abspath(const_values.DEFAULT_TLC_JAR)
     else:
         json_command["jar"] = os.path.abspath(const_values.DEFAULT_APALACHE_JAR)
+
+    if checker == const_values.APALACHE:
+        json_command["args"]["cmd"] = cmd
 
     return json_command
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,17 +28,17 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-deepdiff = "^5.8.1"
-tabulate = "^0.8.9"
+deepdiff = "^6.2.1"
+tabulate = "^0.9.0"
 modelator-py = { git = "https://github.com/informalsystems/modelator-py", branch = "rano/dataclasses" }
-watchdog = "^2.1.8"
-typing-extensions = "^4.2.0"
+watchdog = "^2.1.9"
+typing-extensions = "^4.4.0"
 wget = "^3.2"
 appdirs = "^1.4.4"
 toml = "^0.10.2"
-typer = {extras = ["all"], version = "^0.6.1"}
-rich = "^12.5.1"
-pyrsistent = "^0.18.1"
+typer = {extras = ["all"], version = "^0.7.0"}
+rich = "^12.6.0"
+pyrsistent = "^0.19.2"
 munch = "^2.5.0"
 semver = "^2.13.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 python = "^3.8"
 deepdiff = "^5.8.1"
 tabulate = "^0.8.9"
-modelator-py = "^0.2.3"
+modelator-py = { git = "https://github.com/informalsystems/modelator-py", branch = "rano/dataclasses" }
 watchdog = "^2.1.8"
 typing-extensions = "^4.2.0"
 wget = "^3.2"

--- a/tests/cli/model/transferLegacy.tla
+++ b/tests/cli/model/transferLegacy.tla
@@ -1,0 +1,39 @@
+---- MODULE transferLegacy ----
+EXTENDS Apalache, Integers, FiniteSets
+
+VARIABLES
+    \* @type: Str -> Int;
+    balances,
+    \* @type: [tag: Str, value: [wallets: Set(Str), sender: Str, receiver: Str, amount: Int]];
+    action,
+    \* @type: Int;
+    step
+
+WALLETS == {"Alice", "Bob"}
+
+Init ==
+    /\ balances = [wallet \in WALLETS |-> 100]
+    /\ action = [tag |-> "Init", value |-> [wallets |-> WALLETS]]
+    /\ step = 0
+
+Next ==
+    \E sender \in WALLETS:
+    \E receiver \in WALLETS:
+    \E amount \in 1..balances[sender]:
+        /\ sender /= receiver
+        /\ balances' = [
+            balances EXCEPT
+            ![sender] = @ - amount,
+            ![receiver] = @ + amount
+            ]
+        /\ action' = [tag |-> "Transfer", value |-> [sender |-> sender, receiver |-> receiver, amount |-> amount]]
+    /\ step' = step + 1
+
+View ==
+    IF action.tag = "Transfer"
+    THEN action.value
+    ELSE [sender |-> "", receiver |-> "", amount |-> 0]
+
+TestAliceZero == balances["Alice"] = 0
+
+====

--- a/tests/cli/run-tests.sh
+++ b/tests/cli/run-tests.sh
@@ -22,7 +22,7 @@ test_file() {
     echo "▶️ Testing file $1..."
     $MDX test -v $1
     if [ -f "$1.corrected" ]; then
-        echo "❌ FAILED: see $1.corrected"
+        diff -u "${1}" "${1}.corrected" || echo "❌ FAILED: see $1.corrected"
         SCRIPT_EXIT_CODE=1
     else
         echo "✅ OK"

--- a/tests/cli/test_check.md
+++ b/tests/cli/test_check.md
@@ -30,9 +30,7 @@ Check that the number and length of the generated trace files are as expected:
 
 ```sh
 $ ./traces_num_generated.sh Inv
-1
-$ ./traces_last_generated.sh Inv | xargs -I {} ./traces_length.sh {}
-10
+[1]
 ```
 
 Running `check` trying to prove a property that is not an invariant should fail:
@@ -85,9 +83,7 @@ Check that the number and length of the generated trace files are as expected:
 
 ```sh
 $ ./traces_num_generated.sh Inv
-1
-$ ./traces_last_generated.sh Inv | xargs -I {} ./traces_length.sh {}
-10
+[1]
 $ ./traces_num_generated.sh InvB
 1
 $ ./traces_last_generated.sh InvB | xargs -I {} ./traces_length.sh {}

--- a/tests/cli/test_parse.md
+++ b/tests/cli/test_parse.md
@@ -23,7 +23,7 @@ Parsing error 💥
 ```
 
 ```sh
-$ modelator sample --model-path model/errors/TestError1.tla --examples Inv
+$ modelator sample --model-path model/errors/TestError1.tla --tests Inv
 ...
 Parsing error 💥
 ...

--- a/tests/cli/test_sample.md
+++ b/tests/cli/test_sample.md
@@ -45,7 +45,7 @@ $ ./traces_last_generated.sh ThreeSteps | xargs -I {} ./traces_length.sh {}
 Running `sample` with a model and a property to sample should succeed and generate 3 trace files:
 
 ```sh
-$ modelator sample --model-path model/Test3.tla --tests ThreeSteps --max_error=3
+$ modelator sample --model-path model/Test3.tla --tests ThreeSteps --max_error=3 --view=ThreeSteps
 ...
 - ThreeSteps OK ✅
 ...
@@ -55,7 +55,7 @@ Check that the number and length of the generated trace files are as expected:
 
 ```sh
 $ ./traces_num_generated.sh ThreeSteps
-3
+1
 $ ./traces_last_generated.sh ThreeSteps | xargs -I {} ./traces_length.sh {}
 3
 ```

--- a/tests/cli/test_typecheck.md
+++ b/tests/cli/test_typecheck.md
@@ -40,7 +40,7 @@ Type checking error 💥
 ```
 
 ```sh
-$ modelator sample --model-path model/errors/TestError2.tla --examples Inv
+$ modelator sample --model-path model/errors/TestError2.tla --tests Inv
 ...
 Type checking error 💥
 ...

--- a/tests/cli/test_typecheck.md
+++ b/tests/cli/test_typecheck.md
@@ -30,6 +30,36 @@ $ modelator reset
 ...
 ```
 
+## Run `typecheck` on the model with type old-style type annotations (prior to Apalache 0.29)
+
+```sh
+$ modelator load model/transferLegacy.tla
+...
+```
+
+First, run typecheck with no extra options.
+
+```
+$ modelator typecheck
+Type checking error 💥
+...
+[6]
+```
+
+Then, run typecheck but with an extra option to enable legacy types.
+
+```
+$ modelator typecheck --features=no-rows
+Type checking OK ✅
+```
+
+Clean the generated files after the test:
+
+```sh
+$ modelator reset
+...
+```
+
 ## Run `check` and `sample` on a model with incorrect type annotations
 
 ```sh
@@ -43,5 +73,12 @@ Type checking error 💥
 $ modelator sample --model-path model/errors/TestError2.tla --tests Inv
 ...
 Type checking error 💥
+...
+```
+
+Clean the generated files after the test:
+
+```sh
+$ modelator reset
 ...
 ```

--- a/tests/test_model_check.py
+++ b/tests/test_model_check.py
@@ -35,11 +35,13 @@ def _matching_check_value(
     assert check_result.is_ok == expected_result
     assert (check_result.error_msg is None) == check_result.is_ok
 
-    assert len(check_result.trace_paths) == 1
     trace_filenames = [os.path.basename(p) for p in check_result.trace_paths]
     if check_result.is_ok:
+        assert len(check_result.trace_paths) == 0
+        # doesn't make sense
         assert all([f.startswith("example") for f in trace_filenames])
     else:
+        assert len(check_result.trace_paths) == 1
         assert all([f.startswith("violation") for f in trace_filenames])
 
     # clean traces

--- a/tests/test_model_check.py
+++ b/tests/test_model_check.py
@@ -38,7 +38,6 @@ def _matching_check_value(
     trace_filenames = [os.path.basename(p) for p in check_result.trace_paths]
     if check_result.is_ok:
         assert len(check_result.trace_paths) == 0
-        # doesn't make sense
         assert all([f.startswith("example") for f in trace_filenames])
     else:
         assert len(check_result.trace_paths) == 1


### PR DESCRIPTION
- [x] Support extra args to pass to Apalache.
  - Specifically `--features=no-rows` flag for back compatibility with type system 1. 
- [x] Merge, release and use informalsystems/modelator-py#66