### PR TITLE
modelator tutorial

### DIFF
--- a/examples/hanoi/README.md
+++ b/examples/hanoi/README.md
@@ -1,0 +1,35 @@
+# HanoiTower in Modelator
+
+## Directory structure
+
+### `/hanoi`
+
+Contains the python code for SUT.
+
+### `/model`
+
+Contains the reference TLA+ model of the SUT.
+
+### `/tests`
+
+Tests written using `modelator` library.
+
+The example test should give an idea of how to use modelator as a model-based-testing or MBT library.
+
+### `/traces`
+
+Contains generated traces from TLA+ model via `modelator` executable.
+
+## Code instruction
+
+Generate traces from TLA+ model using `modelator` executable.
+
+```
+modelator sample --model-path model/hanoi.tla --tests Test --traces-dir traces
+```
+
+Execute the test using `pytest`.
+
+```
+python -m pytest -s
+```

--- a/examples/hanoi/README.md
+++ b/examples/hanoi/README.md
@@ -1,4 +1,6 @@
-# HanoiTower in Modelator
+# Tower of Hanoi in Modelator
+
+[About Tower of Hanoi](https://en.wikipedia.org/wiki/Tower_of_Hanoi)
 
 ## Directory structure
 

--- a/examples/hanoi/hanoi/__init__.py
+++ b/examples/hanoi/hanoi/__init__.py
@@ -1,0 +1,27 @@
+from typing import List, Optional, Tuple
+
+
+class HanoiTower:
+    state: Tuple[List[int], List[int], List[int]]
+
+    def __init__(self, n_disc: Optional[int] = None):
+        self.n_disc = n_disc or 3
+        self.state = (list(range(self.n_disc, 0, -1)), [], [])
+
+    def move(self, source: int, target: int):
+        if len(self.state[source - 1]) == 0:
+            raise RuntimeError("Source tower is empty")
+
+        if (
+            len(self.state[target - 1]) > 0
+            and self.state[target - 1][-1] < self.state[source - 1][-1]
+        ):
+            raise RuntimeError("target has smaller disc than source")
+
+        self.state[target - 1].append(self.state[source - 1].pop())
+
+    def is_valid(self) -> bool:
+        return all(sorted(e, reverse=True) == e for e in self.state)
+
+    def is_solved(self) -> bool:
+        return self.state == ([], [], list(range(self.n_disc, 0, -1)))

--- a/examples/hanoi/model/hanoi.tla
+++ b/examples/hanoi/model/hanoi.tla
@@ -4,7 +4,7 @@ EXTENDS Apalache, Integers, Sequences, SequencesExt
 VARIABLES
     \* @type: Seq(Seq(Int));
     hanoi,
-    \* @type: [tag: Str, source: Int, target: Int];
+    \* @type: {tag: Str, source: Int, target: Int};
     action
 
 N_DISC == 3
@@ -17,7 +17,7 @@ INIT_TOWER ==
 
 Init ==
     /\ hanoi = << INIT_TOWER, <<>>, <<>> >>
-    /\ action = [tag |-> "init", n_disc |-> N_DISC]
+    /\ action = [tag |-> "init", source |-> 0, target |-> 0]
 
 
 \* @type: (Int, Int) => Bool;

--- a/examples/hanoi/model/hanoi.tla
+++ b/examples/hanoi/model/hanoi.tla
@@ -1,0 +1,49 @@
+---- MODULE hanoi ----
+EXTENDS Apalache, Integers, Sequences, SequencesExt
+
+VARIABLES
+    \* @type: Seq(Seq(Int));
+    hanoi,
+    \* @type: [tag: Str, source: Int, target: Int];
+    action
+
+N_DISC == 3
+
+INIT_TOWER ==
+    LET
+    \* @type: (Seq(Int), Int) => Seq(Int);
+    NotLambda(s,i) == <<i>> \o s
+    IN ApaFoldSet(NotLambda, <<>>, 1..N_DISC)
+
+Init ==
+    /\ hanoi = << INIT_TOWER, <<>>, <<>> >>
+    /\ action = [tag |-> "init", n_disc |-> N_DISC]
+
+
+\* @type: (Int, Int) => Bool;
+IsValidMove(source, target) ==
+    /\ Len(hanoi[source]) > 0
+    /\ (Len(hanoi[target]) = 0 \/ Last(hanoi[source]) < Last(hanoi[target]))
+
+
+\* @type: (Int, Int) => Seq(Seq(Int));
+Move(source, target) ==
+    [
+        hanoi EXCEPT
+        ![source] = Front(@),
+        ![target] = Append(@, Last(hanoi[source]))
+    ]
+
+
+Next ==
+    \E source \in 1..3, target \in 1..3:
+        /\ source /= target
+        /\ IsValidMove(source, target)
+        /\ hanoi' = Move(source, target)
+        /\ action' = [tag |-> "move", source |-> source, target |-> target]
+
+
+Test ==
+    hanoi = << <<>>, <<>>, INIT_TOWER >>
+
+====

--- a/examples/hanoi/pyproject.toml
+++ b/examples/hanoi/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "hanoi"
+version = "0.1.0"
+description = ""
+authors = ["Ranadeep Biswas <mail@rnbguy.at>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+munch = "^2.5.0"
+pytest = "^7.2.0"
+modelator = "^0.6.4"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/examples/hanoi/tests/test_hanoi.py
+++ b/examples/hanoi/tests/test_hanoi.py
@@ -4,6 +4,8 @@ from munch import Munch
 
 from modelator.pytest.decorators import itf, step
 
+N_DISC = 3
+
 
 # pytest.fixture allows a variable to be persistent through out the test.
 # we want the SUT state to persist during the test.
@@ -17,8 +19,8 @@ def sut():
 # this is done by annotating with `@step(TAG)`.
 @step("init")
 def init(sut, action):
-    print(f"N_DISC: {action.n_disc}")
-    sut.hanoi = HanoiTower(action.n_disc)
+    print(f"N_DISC: {N_DISC}")
+    sut.hanoi = HanoiTower(N_DISC)
 
 
 # note how `action`` variable is automatically available from ITF trace.

--- a/examples/hanoi/tests/test_hanoi.py
+++ b/examples/hanoi/tests/test_hanoi.py
@@ -1,0 +1,38 @@
+import pytest
+from hanoi import HanoiTower
+from munch import Munch
+
+from modelator.pytest.decorators import itf, step
+
+
+# pytest.fixture allows a variable to be persistent through out the test.
+# we want the SUT state to persist during the test.
+# ref: https://docs.pytest.org/en/6.2.x/fixture.html
+@pytest.fixture
+def sut():
+    return Munch()
+
+
+# you have to create hooks for each actions/steps from TLA+ trace steep.
+# this is done by annotating with `@step(TAG)`.
+@step("init")
+def init(sut, action):
+    print(f"N_DISC: {action.n_disc}")
+    sut.hanoi = HanoiTower(action.n_disc)
+
+
+# note how `action`` variable is automatically available from ITF trace.
+@step("move")
+def move(sut, action):
+    print(f"MOVE: {sut.hanoi.state} | {action.source} -> {action.target}")
+    sut.hanoi.move(action.source, action.target)
+    assert sut.hanoi.is_valid()
+
+
+# `@itf(ITF_TRACE_FILE)` annotates a pytest method to use drive the test using that itf trace.
+# `keypath` params denotes a consistent path to a string variable in each ITF trace state
+# it is used to match against tags for each step.
+@itf("traces/Test/violation1.itf.json", keypath="action.tag")
+def test_hanoi(sut):
+    assert sut.hanoi.is_solved()
+    print(f"FINAL: {sut.hanoi.state}")


### PR DESCRIPTION
Closes #287 

Tutorial to generate ITF traces and use `modelator` as `pytest` library to perform model-based testing. 

[Link](https://github.com/informalsystems/modelator/tree/rano/tutorial/examples/hanoi) to directory.