### PR TITLE
check if model file exists before parsing

### DIFF
--- a/modelator/cli/__init__.py
+++ b/modelator/cli/__init__.py
@@ -413,6 +413,11 @@ def _load_model_with_arguments(
 
     model = None
 
+    if os.path.exists(model_path) == False:
+        raise RuntimeError(
+            f"Model file {model_path} does not exist"
+        )
+
     # Load a model from a given path...
     if model_path:
         model = _create_and_parse_model(

--- a/modelator/cli/__init__.py
+++ b/modelator/cli/__init__.py
@@ -413,13 +413,12 @@ def _load_model_with_arguments(
 
     model = None
 
-    if os.path.exists(model_path) == False:
-        raise RuntimeError(
-            f"Model file {model_path} does not exist"
-        )
-
     # Load a model from a given path...
     if model_path:
+        if not os.path.exists(model_path):
+            raise RuntimeError(
+                f"Model file does not exist: {model_path}"
+            )
         model = _create_and_parse_model(
             model_path,
             config["init"],


### PR DESCRIPTION
Instead of showing "parsing error" it now show "model file does not exist" if the model file is missing or path is incorrect.

@rnbguy 